### PR TITLE
Release 2.4.1: sync markdown timestamps to SQLite

### DIFF
--- a/DesktopMemo.sln
+++ b/DesktopMemo.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopMemo.Infrastructure"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopMemo.App", "src\DesktopMemo.App\DesktopMemo.App.csproj", "{ECA3BB45-01DD-444A-9E03-ABDEA7715A4B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopMemo.Infrastructure.Tests", "tests\DesktopMemo.Infrastructure.Tests\DesktopMemo.Infrastructure.Tests.csproj", "{B4F7C2D9-7A0A-4F87-90CC-08BB617D5D5A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,18 @@ Global
 		{ECA3BB45-01DD-444A-9E03-ABDEA7715A4B}.Release|x64.Build.0 = Release|Any CPU
 		{ECA3BB45-01DD-444A-9E03-ABDEA7715A4B}.Release|x86.ActiveCfg = Release|Any CPU
 		{ECA3BB45-01DD-444A-9E03-ABDEA7715A4B}.Release|x86.Build.0 = Release|Any CPU
+		{B4F7C2D9-7A0A-4F87-90CC-08BB617D5D5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4F7C2D9-7A0A-4F87-90CC-08BB617D5D5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4F7C2D9-7A0A-4F87-90CC-08BB617D5D5A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B4F7C2D9-7A0A-4F87-90CC-08BB617D5D5A}.Debug|x64.Build.0 = Debug|Any CPU
+		{B4F7C2D9-7A0A-4F87-90CC-08BB617D5D5A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B4F7C2D9-7A0A-4F87-90CC-08BB617D5D5A}.Debug|x86.Build.0 = Debug|Any CPU
+		{B4F7C2D9-7A0A-4F87-90CC-08BB617D5D5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4F7C2D9-7A0A-4F87-90CC-08BB617D5D5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4F7C2D9-7A0A-4F87-90CC-08BB617D5D5A}.Release|x64.ActiveCfg = Release|Any CPU
+		{B4F7C2D9-7A0A-4F87-90CC-08BB617D5D5A}.Release|x64.Build.0 = Release|Any CPU
+		{B4F7C2D9-7A0A-4F87-90CC-08BB617D5D5A}.Release|x86.ActiveCfg = Release|Any CPU
+		{B4F7C2D9-7A0A-4F87-90CC-08BB617D5D5A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ArtifactsVersion Condition="'$(ArtifactsVersion)'=='' and '$(Version)'!=''">$(Version)</ArtifactsVersion>
-    <ArtifactsVersion Condition="'$(ArtifactsVersion)'==''">2.4.0</ArtifactsVersion>
+    <ArtifactsVersion Condition="'$(ArtifactsVersion)'==''">2.4.1</ArtifactsVersion>
 
     <BaseOutputPath>$(MSBuildThisFileDirectory)artifacts\v$(ArtifactsVersion)\bin\$(MSBuildProjectName)\</BaseOutputPath>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)artifacts\v$(ArtifactsVersion)\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>

--- a/README.md
+++ b/README.md
@@ -153,7 +153,14 @@ DesktopMemo_rebuild/
 
 ## 📝 更新日志
 
-### v2.4.0 (Latest)
+### v2.4.1 (Latest)
+- Bug 修复
+  - 启动时新增 Markdown front matter 时间同步，修复 `.md` 中 `createdAt` / `updatedAt` 无法反映到应用的问题
+  - 修复 SQLite 备忘录时间字段映射，确保列表显示和排序使用正确时间值
+- 测试改进
+  - 新增 Infrastructure 测试项目，覆盖 front matter 解析、时间回写、跳过无效文件等场景
+
+### v2.4.0
 - 功能增强
   - 实现编辑未保存提示功能，移除自动保存机制
   - 添加 Todo 项内联编辑功能

--- a/README_en.md
+++ b/README_en.md
@@ -153,7 +153,14 @@ For other development considerations, see [CONTRIBUTING.md](docs/CONTRIBUTING.md
 
 ## 📝 Changelog
 
-### v2.4.0 (Latest)
+### v2.4.1 (Latest)
+- Bug Fixes
+  - Added startup synchronization from Markdown front matter timestamps to SQLite so `createdAt` / `updatedAt` in `.md` files are reflected in the app
+  - Fixed SQLite memo timestamp field mapping so list display and ordering use the correct values
+- Test Improvements
+  - Added an Infrastructure test project covering front matter parsing, timestamp sync, and invalid file skip scenarios
+
+### v2.4.0
 - Feature Enhancements
   - Implemented unsaved edit prompt and removed auto-save mechanism
   - Added inline editing for Todo items

--- a/src/DesktopMemo.App/App.xaml.cs
+++ b/src/DesktopMemo.App/App.xaml.cs
@@ -39,6 +39,9 @@ public partial class App : WpfApp
         // 数据迁移服务
         services.AddSingleton<TodoMigrationService>();
         services.AddSingleton<MemoMetadataMigrationService>();
+        services.AddSingleton(_ => new MemoFrontMatterTimestampSyncService(
+            dataDirectory,
+            _.GetRequiredService<ILogService>()));
 
         // 窗口和托盘服务
         services.AddSingleton<IWindowService, WindowService>();
@@ -101,6 +104,12 @@ public partial class App : WpfApp
                 System.Diagnostics.Debug.WriteLine($"[App启动] 备忘录索引迁移结果: {memoMigrationResult.Message}");
                 logService.Debug("Migration", $"备忘录索引迁移结果: {memoMigrationResult.Message}");
             }
+
+            // 3. 备忘录时间同步（Markdown front matter -> SQLite）
+            var memoTimestampSyncService = Services.GetRequiredService<MemoFrontMatterTimestampSyncService>();
+            var syncResult = await memoTimestampSyncService.SyncAsync();
+            System.Diagnostics.Debug.WriteLine(
+                $"[App启动] Markdown 时间同步完成: 扫描 {syncResult.ScannedCount}，更新 {syncResult.UpdatedCount}，跳过 {syncResult.SkippedCount}，解析失败 {syncResult.ParseFailureCount}");
             
             System.Diagnostics.Debug.WriteLine("========== 数据迁移检查完成 ==========");
             logService.Info("Migration", "数据迁移检查完成");

--- a/src/DesktopMemo.App/DesktopMemo.App.csproj
+++ b/src/DesktopMemo.App/DesktopMemo.App.csproj
@@ -21,9 +21,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>../images/logo.ico</ApplicationIcon>
     <AssemblyName>DesktopMemo</AssemblyName>
-    <Version>2.4.0</Version>
-    <AssemblyVersion>2.4.0.0</AssemblyVersion>
-    <FileVersion>2.4.0.0</FileVersion>
+    <Version>2.4.1</Version>
+    <AssemblyVersion>2.4.1.0</AssemblyVersion>
+    <FileVersion>2.4.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DesktopMemo.Infrastructure/Memos/MemoMarkdownDocumentReader.cs
+++ b/src/DesktopMemo.Infrastructure/Memos/MemoMarkdownDocumentReader.cs
@@ -10,6 +10,8 @@ internal sealed record MemoMarkdownDocument(string FrontMatter, string Content);
 
 internal static class MemoMarkdownDocumentReader
 {
+    internal const int MaxFrontMatterLength = 64 * 1024;
+
     public static async Task<MemoMarkdownDocument> ReadDocumentAsync(string path, CancellationToken cancellationToken = default)
     {
         var result = await ReadCoreAsync(path, includeContent: true, cancellationToken).ConfigureAwait(false);
@@ -27,12 +29,10 @@ internal static class MemoMarkdownDocumentReader
         bool includeContent,
         CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-
         await using var stream = File.OpenRead(path);
         using var reader = new StreamReader(stream, Encoding.UTF8);
 
-        var firstLine = await reader.ReadLineAsync().ConfigureAwait(false);
+        var firstLine = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
         if (firstLine is null || !firstLine.Equals("---", StringComparison.Ordinal))
         {
             throw new InvalidDataException($"备忘录文件 {path} 缺少 front matter。");
@@ -40,17 +40,20 @@ internal static class MemoMarkdownDocumentReader
 
         var metadataBuilder = new StringBuilder();
         string? line;
-        while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) is not null)
+        while ((line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false)) is not null)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             if (line.Equals("---", StringComparison.Ordinal))
             {
                 var content = includeContent
-                    ? await reader.ReadToEndAsync().ConfigureAwait(false)
+                    ? await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false)
                     : null;
 
                 return (metadataBuilder.ToString(), content);
+            }
+
+            if (metadataBuilder.Length + line.Length + 1 > MaxFrontMatterLength)
+            {
+                throw new InvalidDataException($"备忘录文件 {path} front matter 超出允许大小。");
             }
 
             metadataBuilder.AppendLine(line);

--- a/src/DesktopMemo.Infrastructure/Memos/MemoMarkdownDocumentReader.cs
+++ b/src/DesktopMemo.Infrastructure/Memos/MemoMarkdownDocumentReader.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopMemo.Infrastructure.Memos;
+
+internal sealed record MemoMarkdownDocument(string FrontMatter, string Content);
+
+internal static class MemoMarkdownDocumentReader
+{
+    public static async Task<MemoMarkdownDocument> ReadDocumentAsync(string path, CancellationToken cancellationToken = default)
+    {
+        var result = await ReadCoreAsync(path, includeContent: true, cancellationToken).ConfigureAwait(false);
+        return new MemoMarkdownDocument(result.FrontMatter, result.Content ?? string.Empty);
+    }
+
+    public static async Task<string> ReadFrontMatterAsync(string path, CancellationToken cancellationToken = default)
+    {
+        var result = await ReadCoreAsync(path, includeContent: false, cancellationToken).ConfigureAwait(false);
+        return result.FrontMatter;
+    }
+
+    private static async Task<(string FrontMatter, string? Content)> ReadCoreAsync(
+        string path,
+        bool includeContent,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await using var stream = File.OpenRead(path);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        var firstLine = await reader.ReadLineAsync().ConfigureAwait(false);
+        if (firstLine is null || !firstLine.Equals("---", StringComparison.Ordinal))
+        {
+            throw new InvalidDataException($"备忘录文件 {path} 缺少 front matter。");
+        }
+
+        var metadataBuilder = new StringBuilder();
+        string? line;
+        while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) is not null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (line.Equals("---", StringComparison.Ordinal))
+            {
+                var content = includeContent
+                    ? await reader.ReadToEndAsync().ConfigureAwait(false)
+                    : null;
+
+                return (metadataBuilder.ToString(), content);
+            }
+
+            metadataBuilder.AppendLine(line);
+        }
+
+        throw new InvalidDataException($"备忘录文件 {path} front matter 未正确结束。");
+    }
+}

--- a/src/DesktopMemo.Infrastructure/Memos/MemoMarkdownDocumentReader.cs
+++ b/src/DesktopMemo.Infrastructure/Memos/MemoMarkdownDocumentReader.cs
@@ -51,7 +51,7 @@ internal static class MemoMarkdownDocumentReader
                 return (metadataBuilder.ToString(), content);
             }
 
-            if (metadataBuilder.Length + line.Length + 1 > MaxFrontMatterLength)
+            if (metadataBuilder.Length + line.Length + Environment.NewLine.Length > MaxFrontMatterLength)
             {
                 throw new InvalidDataException($"备忘录文件 {path} front matter 超出允许大小。");
             }

--- a/src/DesktopMemo.Infrastructure/Memos/MemoMarkdownFrontMatterParser.cs
+++ b/src/DesktopMemo.Infrastructure/Memos/MemoMarkdownFrontMatterParser.cs
@@ -28,64 +28,57 @@ internal static class MemoMarkdownFrontMatterParser
         string? line;
         while ((line = reader.ReadLine()) is not null)
         {
-            try
+            if (line.StartsWith("id:", StringComparison.Ordinal))
             {
-                if (line.StartsWith("id:", StringComparison.Ordinal))
+                if (Guid.TryParse(line[3..].Trim(), out var parsedId))
                 {
-                    if (Guid.TryParse(line[3..].Trim(), out var parsedId))
-                    {
-                        id = parsedId;
-                    }
-                }
-                else if (line.StartsWith("title:", StringComparison.Ordinal))
-                {
-                    title = line[6..].Trim().Trim('"');
-                }
-                else if (line.StartsWith("createdAt:", StringComparison.Ordinal))
-                {
-                    if (DateTimeOffset.TryParse(
-                        line[10..].Trim(),
-                        CultureInfo.InvariantCulture,
-                        DateTimeStyles.RoundtripKind,
-                        out var parsedCreatedAt))
-                    {
-                        createdAt = parsedCreatedAt;
-                    }
-                }
-                else if (line.StartsWith("updatedAt:", StringComparison.Ordinal))
-                {
-                    if (DateTimeOffset.TryParse(
-                        line[10..].Trim(),
-                        CultureInfo.InvariantCulture,
-                        DateTimeStyles.RoundtripKind,
-                        out var parsedUpdatedAt))
-                    {
-                        updatedAt = parsedUpdatedAt;
-                    }
-                }
-                else if (line.StartsWith("isPinned:", StringComparison.Ordinal))
-                {
-                    if (bool.TryParse(line[9..].Trim(), out var parsedIsPinned))
-                    {
-                        isPinned = parsedIsPinned;
-                    }
-                }
-                else if (line.TrimStart().StartsWith("-", StringComparison.Ordinal))
-                {
-                    var dashIndex = line.IndexOf('-');
-                    if (dashIndex >= 0)
-                    {
-                        var tag = line[(dashIndex + 1)..].Trim().Trim('"');
-                        if (!string.IsNullOrWhiteSpace(tag))
-                        {
-                            tags.Add(tag);
-                        }
-                    }
+                    id = parsedId;
                 }
             }
-            catch
+            else if (line.StartsWith("title:", StringComparison.Ordinal))
             {
-                continue;
+                title = MemoYamlScalarCodec.Decode(line[6..]);
+            }
+            else if (line.StartsWith("createdAt:", StringComparison.Ordinal))
+            {
+                if (DateTimeOffset.TryParse(
+                    line[10..].Trim(),
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind,
+                    out var parsedCreatedAt))
+                {
+                    createdAt = parsedCreatedAt;
+                }
+            }
+            else if (line.StartsWith("updatedAt:", StringComparison.Ordinal))
+            {
+                if (DateTimeOffset.TryParse(
+                    line[10..].Trim(),
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind,
+                    out var parsedUpdatedAt))
+                {
+                    updatedAt = parsedUpdatedAt;
+                }
+            }
+            else if (line.StartsWith("isPinned:", StringComparison.Ordinal))
+            {
+                if (bool.TryParse(line[9..].Trim(), out var parsedIsPinned))
+                {
+                    isPinned = parsedIsPinned;
+                }
+            }
+            else if (line.TrimStart().StartsWith("-", StringComparison.Ordinal))
+            {
+                var dashIndex = line.IndexOf('-');
+                if (dashIndex >= 0)
+                {
+                    var tag = MemoYamlScalarCodec.Decode(line[(dashIndex + 1)..]);
+                    if (!string.IsNullOrWhiteSpace(tag))
+                    {
+                        tags.Add(tag);
+                    }
+                }
             }
         }
 

--- a/src/DesktopMemo.Infrastructure/Memos/MemoMarkdownFrontMatterParser.cs
+++ b/src/DesktopMemo.Infrastructure/Memos/MemoMarkdownFrontMatterParser.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+
+namespace DesktopMemo.Infrastructure.Memos;
+
+internal sealed record MemoFrontMatter(
+    Guid? Id,
+    string Title,
+    DateTimeOffset? CreatedAt,
+    DateTimeOffset? UpdatedAt,
+    IReadOnlyList<string> Tags,
+    bool IsPinned);
+
+internal static class MemoMarkdownFrontMatterParser
+{
+    public static MemoFrontMatter Parse(string yaml)
+    {
+        Guid? id = null;
+        var title = string.Empty;
+        DateTimeOffset? createdAt = null;
+        DateTimeOffset? updatedAt = null;
+        var isPinned = false;
+        var tags = new List<string>();
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            try
+            {
+                if (line.StartsWith("id:", StringComparison.Ordinal))
+                {
+                    if (Guid.TryParse(line[3..].Trim(), out var parsedId))
+                    {
+                        id = parsedId;
+                    }
+                }
+                else if (line.StartsWith("title:", StringComparison.Ordinal))
+                {
+                    title = line[6..].Trim().Trim('"');
+                }
+                else if (line.StartsWith("createdAt:", StringComparison.Ordinal))
+                {
+                    if (DateTimeOffset.TryParse(
+                        line[10..].Trim(),
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.RoundtripKind,
+                        out var parsedCreatedAt))
+                    {
+                        createdAt = parsedCreatedAt;
+                    }
+                }
+                else if (line.StartsWith("updatedAt:", StringComparison.Ordinal))
+                {
+                    if (DateTimeOffset.TryParse(
+                        line[10..].Trim(),
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.RoundtripKind,
+                        out var parsedUpdatedAt))
+                    {
+                        updatedAt = parsedUpdatedAt;
+                    }
+                }
+                else if (line.StartsWith("isPinned:", StringComparison.Ordinal))
+                {
+                    if (bool.TryParse(line[9..].Trim(), out var parsedIsPinned))
+                    {
+                        isPinned = parsedIsPinned;
+                    }
+                }
+                else if (line.TrimStart().StartsWith("-", StringComparison.Ordinal))
+                {
+                    var dashIndex = line.IndexOf('-');
+                    if (dashIndex >= 0)
+                    {
+                        var tag = line[(dashIndex + 1)..].Trim().Trim('"');
+                        if (!string.IsNullOrWhiteSpace(tag))
+                        {
+                            tags.Add(tag);
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                continue;
+            }
+        }
+
+        return new MemoFrontMatter(id, title, createdAt, updatedAt, tags, isPinned);
+    }
+}

--- a/src/DesktopMemo.Infrastructure/Memos/MemoYamlScalarCodec.cs
+++ b/src/DesktopMemo.Infrastructure/Memos/MemoYamlScalarCodec.cs
@@ -57,15 +57,29 @@ internal static class MemoYamlScalarCodec
             }
 
             i++;
-            builder.Append(trimmed[i] switch
+            var esc = trimmed[i];
+            switch (esc)
             {
-                '\\' => '\\',
-                '"' => '"',
-                'r' => '\r',
-                'n' => '\n',
-                't' => '\t',
-                _ => trimmed[i]
-            });
+                case '\\':
+                    builder.Append('\\');
+                    break;
+                case '"':
+                    builder.Append('"');
+                    break;
+                case 'r':
+                    builder.Append('\r');
+                    break;
+                case 'n':
+                    builder.Append('\n');
+                    break;
+                case 't':
+                    builder.Append('\t');
+                    break;
+                default:
+                    builder.Append('\\');
+                    builder.Append(esc);
+                    break;
+            }
         }
 
         return builder.ToString();

--- a/src/DesktopMemo.Infrastructure/Memos/MemoYamlScalarCodec.cs
+++ b/src/DesktopMemo.Infrastructure/Memos/MemoYamlScalarCodec.cs
@@ -1,0 +1,73 @@
+using System.Text;
+
+namespace DesktopMemo.Infrastructure.Memos;
+
+internal static class MemoYamlScalarCodec
+{
+    public static string Encode(string value)
+    {
+        var builder = new StringBuilder(value.Length + 8);
+        builder.Append('"');
+
+        foreach (var ch in value)
+        {
+            switch (ch)
+            {
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case '"':
+                    builder.Append("\\\"");
+                    break;
+                case '\r':
+                    builder.Append("\\r");
+                    break;
+                case '\n':
+                    builder.Append("\\n");
+                    break;
+                case '\t':
+                    builder.Append("\\t");
+                    break;
+                default:
+                    builder.Append(ch);
+                    break;
+            }
+        }
+
+        builder.Append('"');
+        return builder.ToString();
+    }
+
+    public static string Decode(string value)
+    {
+        var trimmed = value.Trim();
+        if (trimmed.Length < 2 || trimmed[0] != '"' || trimmed[^1] != '"')
+        {
+            return trimmed;
+        }
+
+        var builder = new StringBuilder(trimmed.Length - 2);
+        for (var i = 1; i < trimmed.Length - 1; i++)
+        {
+            var ch = trimmed[i];
+            if (ch != '\\' || i == trimmed.Length - 2)
+            {
+                builder.Append(ch);
+                continue;
+            }
+
+            i++;
+            builder.Append(trimmed[i] switch
+            {
+                '\\' => '\\',
+                '"' => '"',
+                'r' => '\r',
+                'n' => '\n',
+                't' => '\t',
+                _ => trimmed[i]
+            });
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/DesktopMemo.Infrastructure/Properties/AssemblyInfo.cs
+++ b/src/DesktopMemo.Infrastructure/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DesktopMemo.Infrastructure.Tests")]

--- a/src/DesktopMemo.Infrastructure/Repositories/FileMemoRepository.cs
+++ b/src/DesktopMemo.Infrastructure/Repositories/FileMemoRepository.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DesktopMemo.Core.Contracts;
 using DesktopMemo.Core.Models;
+using DesktopMemo.Infrastructure.Memos;
 
 namespace DesktopMemo.Infrastructure.Repositories;
 
@@ -125,41 +126,20 @@ public sealed class FileMemoRepository : IMemoRepository
 
     private async Task<Memo> LoadMemoAsync(string path, CancellationToken cancellationToken)
     {
-        await using var stream = File.OpenRead(path);
-        using var reader = new StreamReader(stream, Encoding.UTF8);
-
-        string? line;
-        var firstLine = await reader.ReadLineAsync().ConfigureAwait(false);
-        if (firstLine is null || !firstLine.Equals("---", StringComparison.Ordinal))
-        {
-            throw new InvalidDataException($"备忘录文件 {path} 缺少 front matter。");
-        }
-
-        var metadataBuilder = new StringBuilder();
-        while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) is not null && !line.Equals("---", StringComparison.Ordinal))
-        {
-            metadataBuilder.AppendLine(line);
-        }
-
-        if (line is null)
-        {
-            throw new InvalidDataException($"备忘录文件 {path} front matter 未正确结束。");
-        }
-
-        var content = await reader.ReadToEndAsync().ConfigureAwait(false);
+        var document = await MemoMarkdownDocumentReader.ReadDocumentAsync(path, cancellationToken).ConfigureAwait(false);
         
         // 获取文件系统时间戳作为后备方案
         var fileInfo = new FileInfo(path);
         var fileCreatedAt = new DateTimeOffset(fileInfo.CreationTimeUtc);
         var fileUpdatedAt = new DateTimeOffset(fileInfo.LastWriteTimeUtc);
         
-        var metadata = ParseMetadata(metadataBuilder.ToString(), fileCreatedAt, fileUpdatedAt);
+        var metadata = ParseMetadata(document.FrontMatter, fileCreatedAt, fileUpdatedAt);
 
         return new Memo(
             metadata.Id,
             metadata.Title,
-            content,
-            BuildPreview(content),
+            document.Content,
+            BuildPreview(document.Content),
             metadata.CreatedAt,
             metadata.UpdatedAt,
             metadata.Tags,
@@ -247,82 +227,14 @@ public sealed class FileMemoRepository : IMemoRepository
 
     private static MemoMetadata ParseMetadata(string yaml, DateTimeOffset fileCreatedAt, DateTimeOffset fileUpdatedAt)
     {
-        var id = Guid.Empty;
-        var title = string.Empty;
-        DateTimeOffset? createdAt = null;
-        DateTimeOffset? updatedAt = null;
-        var isPinned = false;
-        var tags = new List<string>();
-
-        using var reader = new StringReader(yaml);
-        string? line;
-        while ((line = reader.ReadLine()) is not null)
-        {
-            try
-            {
-                if (line.StartsWith("id:", StringComparison.Ordinal))
-                {
-                    if (Guid.TryParse(line[3..].Trim(), out var parsedId))
-                    {
-                        id = parsedId;
-                    }
-                }
-                else if (line.StartsWith("title:", StringComparison.Ordinal))
-                {
-                    title = line[6..].Trim().Trim('"');
-                }
-                else if (line.StartsWith("createdAt:", StringComparison.Ordinal))
-                {
-                    if (DateTimeOffset.TryParse(line[10..].Trim(), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsedCreatedAt))
-                    {
-                        createdAt = parsedCreatedAt;
-                    }
-                }
-                else if (line.StartsWith("updatedAt:", StringComparison.Ordinal))
-                {
-                    if (DateTimeOffset.TryParse(line[10..].Trim(), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsedUpdatedAt))
-                    {
-                        updatedAt = parsedUpdatedAt;
-                    }
-                }
-                else if (line.StartsWith("isPinned:", StringComparison.Ordinal))
-                {
-                    if (bool.TryParse(line[9..].Trim(), out var parsedIsPinned))
-                    {
-                        isPinned = parsedIsPinned;
-                    }
-                }
-                else if (line.TrimStart().StartsWith("-", StringComparison.Ordinal))
-                {
-                    var dashIndex = line.IndexOf('-');
-                    if (dashIndex >= 0)
-                    {
-                        var tag = line.Substring(dashIndex + 1).Trim().Trim('"');
-                        if (!string.IsNullOrWhiteSpace(tag))
-                        {
-                            tags.Add(tag);
-                        }
-                    }
-                }
-            }
-            catch
-            {
-                // 跳过无法解析的行，继续处理其他行
-                continue;
-            }
-        }
-
-        // 如果id为空，生成一个新的id以避免问题
-        if (id == Guid.Empty)
-        {
-            id = Guid.NewGuid();
-        }
+        var frontMatter = MemoMarkdownFrontMatterParser.Parse(yaml);
+        var id = frontMatter.Id ?? Guid.NewGuid();
 
         // 如果 YAML front matter 中没有时间戳，使用文件系统时间作为后备方案
-        var finalCreatedAt = createdAt ?? fileCreatedAt;
-        var finalUpdatedAt = updatedAt ?? fileUpdatedAt;
+        var finalCreatedAt = frontMatter.CreatedAt ?? fileCreatedAt;
+        var finalUpdatedAt = frontMatter.UpdatedAt ?? fileUpdatedAt;
 
-        return new MemoMetadata(id, title, finalCreatedAt, finalUpdatedAt, tags, isPinned);
+        return new MemoMetadata(id, frontMatter.Title, finalCreatedAt, finalUpdatedAt, frontMatter.Tags, frontMatter.IsPinned);
     }
 
     private sealed class MemoIndex

--- a/src/DesktopMemo.Infrastructure/Repositories/FileMemoRepository.cs
+++ b/src/DesktopMemo.Infrastructure/Repositories/FileMemoRepository.cs
@@ -151,14 +151,14 @@ public sealed class FileMemoRepository : IMemoRepository
         var builder = new StringBuilder();
         builder.AppendLine("---");
         builder.AppendLine($"id: {memo.Id}");
-        builder.AppendLine($"title: {EscapeYamlString(memo.Title)}");
+        builder.AppendLine($"title: {MemoYamlScalarCodec.Encode(memo.Title)}");
         builder.AppendLine($"createdAt: {memo.CreatedAt.ToString("O", CultureInfo.InvariantCulture)}");
         builder.AppendLine($"updatedAt: {memo.UpdatedAt.ToString("O", CultureInfo.InvariantCulture)}");
         builder.AppendLine($"isPinned: {memo.IsPinned.ToString(CultureInfo.InvariantCulture)}");
         builder.AppendLine("tags:");
         foreach (var tag in memo.Tags.Distinct(StringComparer.OrdinalIgnoreCase))
         {
-            builder.AppendLine($"  - {EscapeYamlString(tag)}");
+            builder.AppendLine($"  - {MemoYamlScalarCodec.Encode(tag)}");
         }
         builder.AppendLine("---");
         builder.Append(memo.Content);
@@ -186,13 +186,6 @@ public sealed class FileMemoRepository : IMemoRepository
         }
 
         return trimmed.Substring(0, 120) + "...";
-    }
-
-    private static string EscapeYamlString(string value)
-    {
-        return value.Contains(':', StringComparison.Ordinal) || value.Contains('"')
-            ? $"\"{value.Replace("\"", "\\\"", StringComparison.Ordinal)}\""
-            : value;
     }
 
     private async Task<MemoIndex> LoadIndexAsync(CancellationToken cancellationToken)

--- a/src/DesktopMemo.Infrastructure/Repositories/SqliteIndexedMemoRepository.cs
+++ b/src/DesktopMemo.Infrastructure/Repositories/SqliteIndexedMemoRepository.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Dapper;
 using DesktopMemo.Core.Contracts;
 using DesktopMemo.Core.Models;
+using DesktopMemo.Infrastructure.Memos;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 
@@ -468,26 +469,19 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
         var builder = new StringBuilder();
         builder.AppendLine("---");
         builder.AppendLine($"id: {memo.Id}");
-        builder.AppendLine($"title: {EscapeYamlString(memo.Title)}");
+        builder.AppendLine($"title: {MemoYamlScalarCodec.Encode(memo.Title)}");
         builder.AppendLine($"createdAt: {memo.CreatedAt.ToString("O", CultureInfo.InvariantCulture)}");
         builder.AppendLine($"updatedAt: {memo.UpdatedAt.ToString("O", CultureInfo.InvariantCulture)}");
         builder.AppendLine($"isPinned: {memo.IsPinned.ToString(CultureInfo.InvariantCulture)}");
         builder.AppendLine("tags:");
         foreach (var tag in memo.Tags.Distinct(StringComparer.OrdinalIgnoreCase))
         {
-            builder.AppendLine($"  - {EscapeYamlString(tag)}");
+            builder.AppendLine($"  - {MemoYamlScalarCodec.Encode(tag)}");
         }
         builder.AppendLine("---");
         builder.Append(memo.Content);
 
         await File.WriteAllTextAsync(filePath, builder.ToString(), Encoding.UTF8, cancellationToken).ConfigureAwait(false);
-    }
-
-    private static string EscapeYamlString(string value)
-    {
-        return value.Contains(':', StringComparison.Ordinal) || value.Contains('"')
-            ? $"\"{value.Replace("\"", "\\\"", StringComparison.Ordinal)}\""
-            : value;
     }
 
     public void Dispose()

--- a/src/DesktopMemo.Infrastructure/Repositories/SqliteIndexedMemoRepository.cs
+++ b/src/DesktopMemo.Infrastructure/Repositories/SqliteIndexedMemoRepository.cs
@@ -103,14 +103,14 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
                     m.id,
                     m.title,
                     m.preview,
-                    m.is_pinned,
-                    m.created_at,
-                    m.updated_at,
-                    m.file_path,
+                    m.is_pinned AS IsPinned,
+                    m.created_at AS CreatedAt,
+                    m.updated_at AS UpdatedAt,
+                    m.file_path AS FilePath,
                     m.version,
-                    m.sync_status,
-                    m.deleted_at,
-                    GROUP_CONCAT(t.tag) AS tags
+                    m.sync_status AS SyncStatus,
+                    m.deleted_at AS DeletedAt,
+                    GROUP_CONCAT(t.tag) AS Tags
                 FROM memos m
                 LEFT JOIN memo_tags t ON m.id = t.memo_id
                 WHERE m.deleted_at IS NULL
@@ -171,14 +171,14 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
                     m.id,
                     m.title,
                     m.preview,
-                    m.is_pinned,
-                    m.created_at,
-                    m.updated_at,
-                    m.file_path,
+                    m.is_pinned AS IsPinned,
+                    m.created_at AS CreatedAt,
+                    m.updated_at AS UpdatedAt,
+                    m.file_path AS FilePath,
                     m.version,
-                    m.sync_status,
-                    m.deleted_at,
-                    GROUP_CONCAT(t.tag) AS tags
+                    m.sync_status AS SyncStatus,
+                    m.deleted_at AS DeletedAt,
+                    GROUP_CONCAT(t.tag) AS Tags
                 FROM memos m
                 LEFT JOIN memo_tags t ON m.id = t.memo_id
                 WHERE m.id = @Id AND m.deleted_at IS NULL

--- a/src/DesktopMemo.Infrastructure/Services/MemoFrontMatterTimestampSyncService.cs
+++ b/src/DesktopMemo.Infrastructure/Services/MemoFrontMatterTimestampSyncService.cs
@@ -12,18 +12,22 @@ namespace DesktopMemo.Infrastructure.Services;
 
 public sealed class MemoFrontMatterTimestampSyncService
 {
+    private readonly string _dbPath;
+    private readonly string _contentDirectory;
     private readonly string _connectionString;
     private readonly ILogService _logService;
 
     public MemoFrontMatterTimestampSyncService(string dataDirectory, ILogService logService)
     {
-        _connectionString = $"Data Source={Path.Combine(dataDirectory, "memos.db")}";
+        _dbPath = Path.Combine(dataDirectory, "memos.db");
+        _contentDirectory = Path.Combine(dataDirectory, "content");
+        _connectionString = $"Data Source={_dbPath}";
         _logService = logService;
     }
 
     public async Task<MemoFrontMatterTimestampSyncResult> SyncAsync(CancellationToken cancellationToken = default)
     {
-        if (!TryGetDatabasePath(out var dbPath) || !File.Exists(dbPath))
+        if (!File.Exists(_dbPath))
         {
             _logService.Debug("MemoTimestampSync", "未检测到 memos.db，跳过 Markdown 时间同步");
             return new MemoFrontMatterTimestampSyncResult(0, 0, 0, 0);
@@ -49,17 +53,33 @@ public sealed class MemoFrontMatterTimestampSyncService
             cancellationToken.ThrowIfCancellationRequested();
             scannedCount++;
 
-            if (!File.Exists(row.FilePath))
+            if (!Guid.TryParse(row.Id, out var memoId))
             {
                 skippedCount++;
-                _logService.Warning("MemoTimestampSync", $"备忘录文件不存在，跳过时间同步: {row.Id}");
+                parseFailureCount++;
+                _logService.Warning("MemoTimestampSync", $"备忘录 ID 无效，跳过时间同步: {row.Id}");
                 continue;
             }
 
             try
             {
-                var yaml = await MemoMarkdownDocumentReader.ReadFrontMatterAsync(row.FilePath, cancellationToken).ConfigureAwait(false);
+                var filePath = await ResolveFilePathAsync(connection, row, memoId).ConfigureAwait(false);
+                if (filePath is null)
+                {
+                    skippedCount++;
+                    _logService.Warning("MemoTimestampSync", $"备忘录文件不存在，跳过时间同步: {row.Id}");
+                    continue;
+                }
+
+                var yaml = await MemoMarkdownDocumentReader.ReadFrontMatterAsync(filePath, cancellationToken).ConfigureAwait(false);
                 var frontMatter = MemoMarkdownFrontMatterParser.Parse(yaml);
+
+                if (frontMatter.Id is Guid frontMatterId && frontMatterId != memoId)
+                {
+                    skippedCount++;
+                    _logService.Warning("MemoTimestampSync", $"备忘录 front matter ID 与数据库记录不一致，跳过时间同步: {row.Id}");
+                    continue;
+                }
 
                 if (frontMatter.CreatedAt is null || frontMatter.UpdatedAt is null)
                 {
@@ -85,14 +105,22 @@ public sealed class MemoFrontMatterTimestampSyncService
                         updated_at = @UpdatedAt
                     WHERE id = @Id AND deleted_at IS NULL";
 
-                await connection.ExecuteAsync(updateSql, new
+                var rowsAffected = await connection.ExecuteAsync(updateSql, new
                 {
                     row.Id,
                     CreatedAt = markdownCreatedAt.ToString("o", CultureInfo.InvariantCulture),
                     UpdatedAt = markdownUpdatedAt.ToString("o", CultureInfo.InvariantCulture)
                 }).ConfigureAwait(false);
 
-                updatedCount++;
+                if (rowsAffected > 0)
+                {
+                    updatedCount++;
+                }
+                else
+                {
+                    skippedCount++;
+                    _logService.Debug("MemoTimestampSync", $"备忘录记录未更新，可能已被删除: {row.Id}");
+                }
             }
             catch (InvalidDataException ex)
             {
@@ -114,17 +142,34 @@ public sealed class MemoFrontMatterTimestampSyncService
         return new MemoFrontMatterTimestampSyncResult(scannedCount, updatedCount, skippedCount, parseFailureCount);
     }
 
-    private bool TryGetDatabasePath(out string? dbPath)
+    private async Task<string?> ResolveFilePathAsync(SqliteConnection connection, MemoTimestampRow row, Guid memoId)
     {
-        const string prefix = "Data Source=";
-        if (_connectionString.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        if (!string.IsNullOrWhiteSpace(row.FilePath) && File.Exists(row.FilePath))
         {
-            dbPath = _connectionString[prefix.Length..];
-            return true;
+            return row.FilePath;
         }
 
-        dbPath = null;
-        return false;
+        var fallbackPath = Path.Combine(_contentDirectory, $"{memoId:N}.md");
+        if (!File.Exists(fallbackPath))
+        {
+            return null;
+        }
+
+        if (!string.Equals(row.FilePath, fallbackPath, StringComparison.OrdinalIgnoreCase))
+        {
+            const string updatePathSql = @"
+                UPDATE memos
+                SET file_path = @FilePath
+                WHERE id = @Id AND deleted_at IS NULL";
+
+            await connection.ExecuteAsync(updatePathSql, new
+            {
+                FilePath = fallbackPath,
+                row.Id
+            }).ConfigureAwait(false);
+        }
+
+        return fallbackPath;
     }
 
     private static DateTimeOffset? ParseTimestamp(string value)

--- a/src/DesktopMemo.Infrastructure/Services/MemoFrontMatterTimestampSyncService.cs
+++ b/src/DesktopMemo.Infrastructure/Services/MemoFrontMatterTimestampSyncService.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using DesktopMemo.Core.Contracts;
+using DesktopMemo.Infrastructure.Memos;
+using Microsoft.Data.Sqlite;
+
+namespace DesktopMemo.Infrastructure.Services;
+
+public sealed class MemoFrontMatterTimestampSyncService
+{
+    private readonly string _connectionString;
+    private readonly ILogService _logService;
+
+    public MemoFrontMatterTimestampSyncService(string dataDirectory, ILogService logService)
+    {
+        _connectionString = $"Data Source={Path.Combine(dataDirectory, "memos.db")}";
+        _logService = logService;
+    }
+
+    public async Task<MemoFrontMatterTimestampSyncResult> SyncAsync(CancellationToken cancellationToken = default)
+    {
+        if (!TryGetDatabasePath(out var dbPath) || !File.Exists(dbPath))
+        {
+            _logService.Debug("MemoTimestampSync", "未检测到 memos.db，跳过 Markdown 时间同步");
+            return new MemoFrontMatterTimestampSyncResult(0, 0, 0, 0);
+        }
+
+        using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        const string querySql = @"
+            SELECT id, file_path AS FilePath, created_at AS CreatedAt, updated_at AS UpdatedAt
+            FROM memos
+            WHERE deleted_at IS NULL";
+
+        var rows = await connection.QueryAsync<MemoTimestampRow>(querySql).ConfigureAwait(false);
+
+        var scannedCount = 0;
+        var updatedCount = 0;
+        var skippedCount = 0;
+        var parseFailureCount = 0;
+
+        foreach (var row in rows)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            scannedCount++;
+
+            if (!File.Exists(row.FilePath))
+            {
+                skippedCount++;
+                _logService.Warning("MemoTimestampSync", $"备忘录文件不存在，跳过时间同步: {row.Id}");
+                continue;
+            }
+
+            try
+            {
+                var yaml = await MemoMarkdownDocumentReader.ReadFrontMatterAsync(row.FilePath, cancellationToken).ConfigureAwait(false);
+                var frontMatter = MemoMarkdownFrontMatterParser.Parse(yaml);
+
+                if (frontMatter.CreatedAt is null || frontMatter.UpdatedAt is null)
+                {
+                    skippedCount++;
+                    parseFailureCount++;
+                    _logService.Warning("MemoTimestampSync", $"备忘录 front matter 时间缺失或无效，跳过时间同步: {row.Id}");
+                    continue;
+                }
+
+                var markdownCreatedAt = frontMatter.CreatedAt.Value;
+                var markdownUpdatedAt = frontMatter.UpdatedAt.Value;
+                var dbCreatedAt = ParseTimestamp(row.CreatedAt);
+                var dbUpdatedAt = ParseTimestamp(row.UpdatedAt);
+
+                if (dbCreatedAt == markdownCreatedAt && dbUpdatedAt == markdownUpdatedAt)
+                {
+                    continue;
+                }
+
+                const string updateSql = @"
+                    UPDATE memos
+                    SET created_at = @CreatedAt,
+                        updated_at = @UpdatedAt
+                    WHERE id = @Id AND deleted_at IS NULL";
+
+                await connection.ExecuteAsync(updateSql, new
+                {
+                    row.Id,
+                    CreatedAt = markdownCreatedAt.ToString("o", CultureInfo.InvariantCulture),
+                    UpdatedAt = markdownUpdatedAt.ToString("o", CultureInfo.InvariantCulture)
+                }).ConfigureAwait(false);
+
+                updatedCount++;
+            }
+            catch (InvalidDataException ex)
+            {
+                skippedCount++;
+                parseFailureCount++;
+                _logService.Warning("MemoTimestampSync", $"备忘录 front matter 读取失败，跳过时间同步: {row.Id}，原因: {ex.Message}");
+            }
+            catch (IOException ex)
+            {
+                skippedCount++;
+                _logService.Warning("MemoTimestampSync", $"备忘录文件读取失败，跳过时间同步: {row.Id}，原因: {ex.Message}");
+            }
+        }
+
+        _logService.Info(
+            "MemoTimestampSync",
+            $"Markdown 时间同步完成: 扫描 {scannedCount}，更新 {updatedCount}，跳过 {skippedCount}，解析失败 {parseFailureCount}");
+
+        return new MemoFrontMatterTimestampSyncResult(scannedCount, updatedCount, skippedCount, parseFailureCount);
+    }
+
+    private bool TryGetDatabasePath(out string? dbPath)
+    {
+        const string prefix = "Data Source=";
+        if (_connectionString.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            dbPath = _connectionString[prefix.Length..];
+            return true;
+        }
+
+        dbPath = null;
+        return false;
+    }
+
+    private static DateTimeOffset? ParseTimestamp(string value)
+    {
+        if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var result))
+        {
+            return result;
+        }
+
+        return null;
+    }
+
+    private sealed class MemoTimestampRow
+    {
+        public string Id { get; set; } = string.Empty;
+        public string FilePath { get; set; } = string.Empty;
+        public string CreatedAt { get; set; } = string.Empty;
+        public string UpdatedAt { get; set; } = string.Empty;
+    }
+}
+
+public sealed record MemoFrontMatterTimestampSyncResult(
+    int ScannedCount,
+    int UpdatedCount,
+    int SkippedCount,
+    int ParseFailureCount);

--- a/tests/DesktopMemo.Infrastructure.Tests/DesktopMemo.Infrastructure.Tests.csproj
+++ b/tests/DesktopMemo.Infrastructure.Tests/DesktopMemo.Infrastructure.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DesktopMemo.Infrastructure\DesktopMemo.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\DesktopMemo.Core\DesktopMemo.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/DesktopMemo.Infrastructure.Tests/MemoFrontMatterParsingTests.cs
+++ b/tests/DesktopMemo.Infrastructure.Tests/MemoFrontMatterParsingTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using DesktopMemo.Infrastructure.Memos;
+using Xunit;
+
+namespace DesktopMemo.Infrastructure.Tests;
+
+public sealed class MemoFrontMatterParsingTests
+{
+    [Fact]
+    public async Task ReadFrontMatterAndParse_ReturnsExplicitTimestamps()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var filePath = Path.Combine(tempDirectory.Path, "memo.md");
+
+        await File.WriteAllTextAsync(filePath, """
+            ---
+            id: 7cbfdb90-1d74-4332-b2e9-4757830bd33d
+            title: 时间测试
+            createdAt: 2026-03-10T19:44:47.4679167+08:00
+            updatedAt: 2026-03-10T19:44:50.6879260+08:00
+            isPinned: True
+            tags:
+              - alpha
+              - beta
+            ---
+            body
+            """);
+
+        var yaml = await MemoMarkdownDocumentReader.ReadFrontMatterAsync(filePath);
+        var frontMatter = MemoMarkdownFrontMatterParser.Parse(yaml);
+
+        Assert.Equal(Guid.Parse("7cbfdb90-1d74-4332-b2e9-4757830bd33d"), frontMatter.Id);
+        Assert.Equal("时间测试", frontMatter.Title);
+        Assert.Equal(DateTimeOffset.Parse("2026-03-10T19:44:47.4679167+08:00"), frontMatter.CreatedAt);
+        Assert.Equal(DateTimeOffset.Parse("2026-03-10T19:44:50.6879260+08:00"), frontMatter.UpdatedAt);
+        Assert.True(frontMatter.IsPinned);
+        Assert.Equal(["alpha", "beta"], frontMatter.Tags);
+    }
+}

--- a/tests/DesktopMemo.Infrastructure.Tests/MemoFrontMatterParsingTests.cs
+++ b/tests/DesktopMemo.Infrastructure.Tests/MemoFrontMatterParsingTests.cs
@@ -83,4 +83,44 @@ public sealed class MemoFrontMatterParsingTests
 
         await Assert.ThrowsAsync<InvalidDataException>(() => MemoMarkdownDocumentReader.ReadFrontMatterAsync(filePath));
     }
+
+    [Fact]
+    public async Task ReadFrontMatterAsync_AllowsFrontMatter_AtExactLimit()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var filePath = Path.Combine(tempDirectory.Path, "memo.md");
+        var exactLineLength = MemoMarkdownDocumentReader.MaxFrontMatterLength - Environment.NewLine.Length;
+        var exactLine = new string('a', exactLineLength);
+
+        await File.WriteAllTextAsync(
+            filePath,
+            $"---{Environment.NewLine}{exactLine}{Environment.NewLine}---{Environment.NewLine}body");
+
+        var frontMatter = await MemoMarkdownDocumentReader.ReadFrontMatterAsync(filePath);
+
+        Assert.Equal(exactLine + Environment.NewLine, frontMatter);
+    }
+
+    [Fact]
+    public async Task ReadFrontMatterAsync_Throws_WhenFrontMatterExceedsLimitByOneCharacter()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var filePath = Path.Combine(tempDirectory.Path, "memo.md");
+        var tooLongLineLength = MemoMarkdownDocumentReader.MaxFrontMatterLength - Environment.NewLine.Length + 1;
+        var tooLongLine = new string('a', tooLongLineLength);
+
+        await File.WriteAllTextAsync(
+            filePath,
+            $"---{Environment.NewLine}{tooLongLine}{Environment.NewLine}---{Environment.NewLine}body");
+
+        await Assert.ThrowsAsync<InvalidDataException>(() => MemoMarkdownDocumentReader.ReadFrontMatterAsync(filePath));
+    }
+
+    [Fact]
+    public void Decode_PreservesBackslash_ForUnknownEscapeSequences()
+    {
+        var decoded = MemoYamlScalarCodec.Decode("\"C:\\path\\p\"");
+
+        Assert.Equal(@"C:\path\p", decoded);
+    }
 }

--- a/tests/DesktopMemo.Infrastructure.Tests/MemoFrontMatterParsingTests.cs
+++ b/tests/DesktopMemo.Infrastructure.Tests/MemoFrontMatterParsingTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using DesktopMemo.Infrastructure.Memos;
+using DesktopMemo.Infrastructure.Repositories;
 using Xunit;
 
 namespace DesktopMemo.Infrastructure.Tests;
@@ -37,5 +38,49 @@ public sealed class MemoFrontMatterParsingTests
         Assert.Equal(DateTimeOffset.Parse("2026-03-10T19:44:50.6879260+08:00"), frontMatter.UpdatedAt);
         Assert.True(frontMatter.IsPinned);
         Assert.Equal(["alpha", "beta"], frontMatter.Tags);
+    }
+
+    [Fact]
+    public async Task ReadFrontMatterAndParse_RoundTripsEscapedYamlScalars()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repository = new FileMemoRepository(tempDirectory.Path);
+        var memo = new DesktopMemo.Core.Models.Memo(
+            Guid.NewGuid(),
+            "标题: \"引号\"\n第二行\\路径",
+            "body",
+            "body",
+            DateTimeOffset.Parse("2026-03-10T19:44:47.4679167+08:00"),
+            DateTimeOffset.Parse("2026-03-10T19:44:50.6879260+08:00"),
+            ["tag:one", "tag\"two", "tag\nthree", "path\\tag"],
+            false);
+
+        await repository.AddAsync(memo);
+
+        var filePath = Path.Combine(tempDirectory.Path, "content", $"{memo.Id:N}.md");
+        var yaml = await MemoMarkdownDocumentReader.ReadFrontMatterAsync(filePath);
+        var parsed = MemoMarkdownFrontMatterParser.Parse(yaml);
+
+        Assert.Contains("title: \"标题: \\\"引号\\\"\\n第二行\\\\路径\"", yaml);
+        Assert.Contains("- \"tag\\nthree\"", yaml);
+        Assert.Equal(memo.Title, parsed.Title);
+        Assert.Equal(memo.Tags, parsed.Tags);
+    }
+
+    [Fact]
+    public async Task ReadFrontMatterAsync_Throws_WhenFrontMatterExceedsLimit()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var filePath = Path.Combine(tempDirectory.Path, "memo.md");
+        var oversizedLine = new string('a', MemoMarkdownDocumentReader.MaxFrontMatterLength + 1);
+
+        await File.WriteAllTextAsync(filePath, $$"""
+            ---
+            title: "{{oversizedLine}}"
+            ---
+            body
+            """);
+
+        await Assert.ThrowsAsync<InvalidDataException>(() => MemoMarkdownDocumentReader.ReadFrontMatterAsync(filePath));
     }
 }

--- a/tests/DesktopMemo.Infrastructure.Tests/MemoFrontMatterTimestampSyncServiceTests.cs
+++ b/tests/DesktopMemo.Infrastructure.Tests/MemoFrontMatterTimestampSyncServiceTests.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using DesktopMemo.Core.Contracts;
+using DesktopMemo.Core.Models;
+using DesktopMemo.Infrastructure.Repositories;
+using DesktopMemo.Infrastructure.Services;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace DesktopMemo.Infrastructure.Tests;
+
+public sealed class MemoFrontMatterTimestampSyncServiceTests
+{
+    [Fact]
+    public async Task SyncAsync_UpdatesSqliteTimestamps_WhenMarkdownFrontMatterDiffers()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        using var repository = new SqliteIndexedMemoRepository(tempDirectory.Path);
+        var logger = new TestLogService();
+        var service = new MemoFrontMatterTimestampSyncService(tempDirectory.Path, logger);
+
+        var id = Guid.NewGuid();
+        var initialCreatedAt = DateTimeOffset.Parse("2026-03-10T10:00:00+08:00");
+        var initialUpdatedAt = DateTimeOffset.Parse("2026-03-10T10:05:00+08:00");
+        var syncedCreatedAt = DateTimeOffset.Parse("2026-03-01T08:00:00+08:00");
+        var syncedUpdatedAt = DateTimeOffset.Parse("2026-03-11T22:30:00+08:00");
+
+        await repository.AddAsync(CreateMemo(id, initialCreatedAt, initialUpdatedAt));
+        await File.WriteAllTextAsync(GetMemoPath(tempDirectory.Path, id), BuildMarkdown(id, syncedCreatedAt, syncedUpdatedAt));
+
+        var result = await service.SyncAsync();
+        var reloaded = await repository.GetByIdAsync(id);
+
+        Assert.NotNull(reloaded);
+        Assert.Equal(1, result.ScannedCount);
+        Assert.Equal(1, result.UpdatedCount);
+        Assert.Equal(0, result.SkippedCount);
+        Assert.Equal(syncedCreatedAt, reloaded!.CreatedAt);
+        Assert.Equal(syncedUpdatedAt, reloaded.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task SyncAsync_DoesNotUpdate_WhenMarkdownMatchesSqlite()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        using var repository = new SqliteIndexedMemoRepository(tempDirectory.Path);
+        var logger = new TestLogService();
+        var service = new MemoFrontMatterTimestampSyncService(tempDirectory.Path, logger);
+
+        var id = Guid.NewGuid();
+        var createdAt = DateTimeOffset.Parse("2026-03-10T10:00:00+08:00");
+        var updatedAt = DateTimeOffset.Parse("2026-03-10T10:05:00+08:00");
+
+        await repository.AddAsync(CreateMemo(id, createdAt, updatedAt));
+
+        var result = await service.SyncAsync();
+
+        Assert.Equal(1, result.ScannedCount);
+        Assert.Equal(0, result.UpdatedCount);
+        Assert.Equal(0, result.SkippedCount);
+        Assert.Equal(0, result.ParseFailureCount);
+    }
+
+    [Fact]
+    public async Task SyncAsync_SkipsFile_WhenUpdatedAtIsInvalid()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        using var repository = new SqliteIndexedMemoRepository(tempDirectory.Path);
+        var logger = new TestLogService();
+        var service = new MemoFrontMatterTimestampSyncService(tempDirectory.Path, logger);
+
+        var id = Guid.NewGuid();
+        var createdAt = DateTimeOffset.Parse("2026-03-10T10:00:00+08:00");
+        var updatedAt = DateTimeOffset.Parse("2026-03-10T10:05:00+08:00");
+
+        await repository.AddAsync(CreateMemo(id, createdAt, updatedAt));
+        await File.WriteAllTextAsync(GetMemoPath(tempDirectory.Path, id), $$"""
+            ---
+            id: {{id}}
+            title: 无效时间
+            createdAt: 2026-03-01T08:00:00+08:00
+            updatedAt: invalid
+            isPinned: False
+            tags:
+            ---
+            body
+            """);
+
+        var result = await service.SyncAsync();
+        var dbRow = await ReadDatabaseRowAsync(tempDirectory.Path, id);
+
+        Assert.Equal(1, result.ScannedCount);
+        Assert.Equal(0, result.UpdatedCount);
+        Assert.Equal(1, result.SkippedCount);
+        Assert.Equal(1, result.ParseFailureCount);
+        Assert.NotNull(dbRow);
+        Assert.Equal(createdAt.ToString("o"), dbRow!.Value.CreatedAt);
+        Assert.Equal(updatedAt.ToString("o"), dbRow.Value.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task SyncAsync_SkipsFile_WhenMarkdownIsMissing()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        using var repository = new SqliteIndexedMemoRepository(tempDirectory.Path);
+        var logger = new TestLogService();
+        var service = new MemoFrontMatterTimestampSyncService(tempDirectory.Path, logger);
+
+        var id = Guid.NewGuid();
+        await repository.AddAsync(CreateMemo(
+            id,
+            DateTimeOffset.Parse("2026-03-10T10:00:00+08:00"),
+            DateTimeOffset.Parse("2026-03-10T10:05:00+08:00")));
+
+        File.Delete(GetMemoPath(tempDirectory.Path, id));
+
+        var result = await service.SyncAsync();
+
+        Assert.Equal(1, result.ScannedCount);
+        Assert.Equal(0, result.UpdatedCount);
+        Assert.Equal(1, result.SkippedCount);
+        Assert.Equal(0, result.ParseFailureCount);
+    }
+
+    [Fact]
+    public async Task SyncAsync_IgnoresSoftDeletedMemos()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        using var repository = new SqliteIndexedMemoRepository(tempDirectory.Path);
+        var logger = new TestLogService();
+        var service = new MemoFrontMatterTimestampSyncService(tempDirectory.Path, logger);
+
+        var id = Guid.NewGuid();
+        await repository.AddAsync(CreateMemo(
+            id,
+            DateTimeOffset.Parse("2026-03-10T10:00:00+08:00"),
+            DateTimeOffset.Parse("2026-03-10T10:05:00+08:00")));
+        await repository.DeleteAsync(id);
+
+        var result = await service.SyncAsync();
+
+        Assert.Equal(0, result.ScannedCount);
+        Assert.Equal(0, result.UpdatedCount);
+        Assert.Equal(0, result.SkippedCount);
+        Assert.Equal(0, result.ParseFailureCount);
+    }
+
+    private static Memo CreateMemo(Guid id, DateTimeOffset createdAt, DateTimeOffset updatedAt)
+    {
+        return new Memo(id, "标题", "body", "body", createdAt, updatedAt, Array.Empty<string>(), false);
+    }
+
+    private static string GetMemoPath(string dataDirectory, Guid id)
+    {
+        return Path.Combine(dataDirectory, "content", $"{id:N}.md");
+    }
+
+    private static string BuildMarkdown(Guid id, DateTimeOffset createdAt, DateTimeOffset updatedAt)
+    {
+        return $$"""
+            ---
+            id: {{id}}
+            title: 标题
+            createdAt: {{createdAt:o}}
+            updatedAt: {{updatedAt:o}}
+            isPinned: False
+            tags:
+            ---
+            body
+            """;
+    }
+
+    private static async Task<(string CreatedAt, string UpdatedAt)?> ReadDatabaseRowAsync(string dataDirectory, Guid id)
+    {
+        var dbPath = Path.Combine(dataDirectory, "memos.db");
+        await using var connection = new SqliteConnection($"Data Source={dbPath}");
+        await connection.OpenAsync();
+
+        var command = connection.CreateCommand();
+        command.CommandText = "SELECT created_at, updated_at FROM memos WHERE id = $id";
+        command.Parameters.AddWithValue("$id", id.ToString());
+
+        await using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+        {
+            return null;
+        }
+
+        return (reader.GetString(0), reader.GetString(1));
+    }
+}
+
+internal sealed class TestLogService : ILogService
+{
+    private readonly List<LogEntry> _logs = new();
+
+    public event EventHandler<LogEntry>? LogAdded;
+
+    public void Debug(string source, string message) => Add(new LogEntry(DateTimeOffset.Now, LogLevel.Debug, source, message));
+
+    public void Info(string source, string message) => Add(new LogEntry(DateTimeOffset.Now, LogLevel.Info, source, message));
+
+    public void Warning(string source, string message) => Add(new LogEntry(DateTimeOffset.Now, LogLevel.Warning, source, message));
+
+    public void Error(string source, string message, Exception? exception = null) =>
+        Add(new LogEntry(DateTimeOffset.Now, LogLevel.Error, source, message, exception));
+
+    public void Log(LogEntry entry) => Add(entry);
+
+    public IReadOnlyList<LogEntry> GetAllLogs() => _logs;
+
+    public IReadOnlyList<LogEntry> GetLogsByLevel(LogLevel minLevel) => _logs.FindAll(log => log.Level >= minLevel);
+
+    public void ClearLogs() => _logs.Clear();
+
+    public Task<IReadOnlyList<LogEntry>> LoadHistoryLogsAsync(int maxCount = 1000) =>
+        Task.FromResult<IReadOnlyList<LogEntry>>(_logs);
+
+    private void Add(LogEntry entry)
+    {
+        _logs.Add(entry);
+        LogAdded?.Invoke(this, entry);
+    }
+}
+
+internal sealed class TemporaryDirectory : IDisposable
+{
+    public TemporaryDirectory()
+    {
+        Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "DesktopMemoTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path);
+    }
+
+    public string Path { get; }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+
+        if (Directory.Exists(Path))
+        {
+            for (var attempt = 0; attempt < 3; attempt++)
+            {
+                try
+                {
+                    Directory.Delete(Path, recursive: true);
+                    break;
+                }
+                catch (IOException) when (attempt < 2)
+                {
+                    Task.Delay(50).GetAwaiter().GetResult();
+                }
+            }
+        }
+    }
+}

--- a/tests/DesktopMemo.Infrastructure.Tests/MemoFrontMatterTimestampSyncServiceTests.cs
+++ b/tests/DesktopMemo.Infrastructure.Tests/MemoFrontMatterTimestampSyncServiceTests.cs
@@ -89,7 +89,7 @@ public sealed class MemoFrontMatterTimestampSyncServiceTests
             """);
 
         var result = await service.SyncAsync();
-        var dbRow = await ReadDatabaseRowAsync(tempDirectory.Path, id);
+        var dbRow = await ReadDatabaseRecordAsync(tempDirectory.Path, id);
 
         Assert.Equal(1, result.ScannedCount);
         Assert.Equal(0, result.UpdatedCount);
@@ -122,6 +122,119 @@ public sealed class MemoFrontMatterTimestampSyncServiceTests
         Assert.Equal(0, result.UpdatedCount);
         Assert.Equal(1, result.SkippedCount);
         Assert.Equal(0, result.ParseFailureCount);
+    }
+
+    [Fact]
+    public async Task SyncAsync_UsesFallbackPath_AndSelfHealsFilePath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        using var repository = new SqliteIndexedMemoRepository(tempDirectory.Path);
+        var logger = new TestLogService();
+        var service = new MemoFrontMatterTimestampSyncService(tempDirectory.Path, logger);
+
+        var id = Guid.NewGuid();
+        var createdAt = DateTimeOffset.Parse("2026-03-10T10:00:00+08:00");
+        var updatedAt = DateTimeOffset.Parse("2026-03-10T10:05:00+08:00");
+        var syncedUpdatedAt = DateTimeOffset.Parse("2026-03-12T11:15:00+08:00");
+
+        await repository.AddAsync(CreateMemo(id, createdAt, updatedAt));
+        await File.WriteAllTextAsync(GetMemoPath(tempDirectory.Path, id), BuildMarkdown(id, createdAt, syncedUpdatedAt));
+        await SetFilePathAsync(tempDirectory.Path, id, Path.Combine(tempDirectory.Path, "content", "stale.md"));
+
+        var result = await service.SyncAsync();
+        var dbRow = await ReadDatabaseRecordAsync(tempDirectory.Path, id);
+
+        Assert.Equal(1, result.ScannedCount);
+        Assert.Equal(1, result.UpdatedCount);
+        Assert.NotNull(dbRow);
+        Assert.Equal(GetMemoPath(tempDirectory.Path, id), dbRow!.Value.FilePath);
+        Assert.Equal(syncedUpdatedAt.ToString("o"), dbRow.Value.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task SyncAsync_SkipsFile_WhenFrontMatterIdDoesNotMatchDatabaseRow()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        using var repository = new SqliteIndexedMemoRepository(tempDirectory.Path);
+        var logger = new TestLogService();
+        var service = new MemoFrontMatterTimestampSyncService(tempDirectory.Path, logger);
+
+        var id = Guid.NewGuid();
+        var otherId = Guid.NewGuid();
+        var createdAt = DateTimeOffset.Parse("2026-03-10T10:00:00+08:00");
+        var updatedAt = DateTimeOffset.Parse("2026-03-10T10:05:00+08:00");
+
+        await repository.AddAsync(CreateMemo(id, createdAt, updatedAt));
+        await File.WriteAllTextAsync(GetMemoPath(tempDirectory.Path, id), BuildMarkdown(otherId, createdAt.AddDays(-1), updatedAt.AddDays(1)));
+
+        var result = await service.SyncAsync();
+        var dbRow = await ReadDatabaseRecordAsync(tempDirectory.Path, id);
+
+        Assert.Equal(1, result.ScannedCount);
+        Assert.Equal(0, result.UpdatedCount);
+        Assert.Equal(1, result.SkippedCount);
+        Assert.NotNull(dbRow);
+        Assert.Equal(createdAt.ToString("o"), dbRow!.Value.CreatedAt);
+        Assert.Equal(updatedAt.ToString("o"), dbRow.Value.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task SyncAsync_SkipsFile_WhenFrontMatterExceedsLimit()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        using var repository = new SqliteIndexedMemoRepository(tempDirectory.Path);
+        var logger = new TestLogService();
+        var service = new MemoFrontMatterTimestampSyncService(tempDirectory.Path, logger);
+
+        var id = Guid.NewGuid();
+        await repository.AddAsync(CreateMemo(
+            id,
+            DateTimeOffset.Parse("2026-03-10T10:00:00+08:00"),
+            DateTimeOffset.Parse("2026-03-10T10:05:00+08:00")));
+
+        var oversizedLine = new string('b', DesktopMemo.Infrastructure.Memos.MemoMarkdownDocumentReader.MaxFrontMatterLength + 1);
+        await File.WriteAllTextAsync(GetMemoPath(tempDirectory.Path, id), $$"""
+            ---
+            title: "{{oversizedLine}}"
+            createdAt: 2026-03-10T10:00:00+08:00
+            updatedAt: 2026-03-10T10:05:00+08:00
+            ---
+            body
+            """);
+
+        var result = await service.SyncAsync();
+
+        Assert.Equal(1, result.ScannedCount);
+        Assert.Equal(0, result.UpdatedCount);
+        Assert.Equal(1, result.SkippedCount);
+        Assert.Equal(1, result.ParseFailureCount);
+    }
+
+    [Fact]
+    public async Task SyncAsync_CountsSkipped_WhenUpdateAffectsZeroRows()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        using var repository = new SqliteIndexedMemoRepository(tempDirectory.Path);
+        var logger = new TestLogService();
+        var service = new MemoFrontMatterTimestampSyncService(tempDirectory.Path, logger);
+
+        var id = Guid.NewGuid();
+        var createdAt = DateTimeOffset.Parse("2026-03-10T10:00:00+08:00");
+        var updatedAt = DateTimeOffset.Parse("2026-03-10T10:05:00+08:00");
+
+        await repository.AddAsync(CreateMemo(id, createdAt, updatedAt));
+        await File.WriteAllTextAsync(GetMemoPath(tempDirectory.Path, id), BuildMarkdown(id, createdAt.AddDays(-2), updatedAt.AddDays(2)));
+        await CreateIgnoreUpdateTriggerAsync(tempDirectory.Path, id);
+
+        var result = await service.SyncAsync();
+        var dbRow = await ReadDatabaseRecordAsync(tempDirectory.Path, id);
+
+        Assert.Equal(1, result.ScannedCount);
+        Assert.Equal(0, result.UpdatedCount);
+        Assert.Equal(1, result.SkippedCount);
+        Assert.NotNull(dbRow);
+        Assert.Equal(createdAt.ToString("o"), dbRow!.Value.CreatedAt);
+        Assert.Equal(updatedAt.ToString("o"), dbRow.Value.UpdatedAt);
     }
 
     [Fact]
@@ -162,7 +275,7 @@ public sealed class MemoFrontMatterTimestampSyncServiceTests
         return $$"""
             ---
             id: {{id}}
-            title: 标题
+            title: "标题"
             createdAt: {{createdAt:o}}
             updatedAt: {{updatedAt:o}}
             isPinned: False
@@ -172,14 +285,45 @@ public sealed class MemoFrontMatterTimestampSyncServiceTests
             """;
     }
 
-    private static async Task<(string CreatedAt, string UpdatedAt)?> ReadDatabaseRowAsync(string dataDirectory, Guid id)
+    private static async Task SetFilePathAsync(string dataDirectory, Guid id, string filePath)
     {
         var dbPath = Path.Combine(dataDirectory, "memos.db");
         await using var connection = new SqliteConnection($"Data Source={dbPath}");
         await connection.OpenAsync();
 
         var command = connection.CreateCommand();
-        command.CommandText = "SELECT created_at, updated_at FROM memos WHERE id = $id";
+        command.CommandText = "UPDATE memos SET file_path = $filePath WHERE id = $id";
+        command.Parameters.AddWithValue("$filePath", filePath);
+        command.Parameters.AddWithValue("$id", id.ToString());
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static async Task CreateIgnoreUpdateTriggerAsync(string dataDirectory, Guid id)
+    {
+        var dbPath = Path.Combine(dataDirectory, "memos.db");
+        await using var connection = new SqliteConnection($"Data Source={dbPath}");
+        await connection.OpenAsync();
+
+        var command = connection.CreateCommand();
+        command.CommandText = $$"""
+            CREATE TRIGGER ignore_memo_update
+            BEFORE UPDATE OF created_at, updated_at ON memos
+            WHEN OLD.id = '{{id}}'
+            BEGIN
+                SELECT RAISE(IGNORE);
+            END;
+            """;
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<(string CreatedAt, string UpdatedAt, string FilePath)?> ReadDatabaseRecordAsync(string dataDirectory, Guid id)
+    {
+        var dbPath = Path.Combine(dataDirectory, "memos.db");
+        await using var connection = new SqliteConnection($"Data Source={dbPath}");
+        await connection.OpenAsync();
+
+        var command = connection.CreateCommand();
+        command.CommandText = "SELECT created_at, updated_at, file_path FROM memos WHERE id = $id";
         command.Parameters.AddWithValue("$id", id.ToString());
 
         await using var reader = await command.ExecuteReaderAsync();
@@ -188,7 +332,7 @@ public sealed class MemoFrontMatterTimestampSyncServiceTests
             return null;
         }
 
-        return (reader.GetString(0), reader.GetString(1));
+        return (reader.GetString(0), reader.GetString(1), reader.GetString(2));
     }
 }
 


### PR DESCRIPTION
## 背景
- 修复 Markdown front matter 中 `createdAt` / `updatedAt` 已存在，但应用未按其显示时间的问题
- 发布版本提升至 `2.4.1`

## 变更摘要
- 启动阶段新增 Markdown front matter 时间同步服务，将 `.md` 中的 `createdAt` / `updatedAt` 回写到 SQLite
- 抽出共享的 front matter 读取与解析逻辑，复用于文件仓储和启动同步流程
- 修复 `SqliteIndexedMemoRepository` 中备忘录时间字段映射，确保列表显示和排序使用正确时间
- 新增 Infrastructure 测试项目，覆盖 front matter 解析、时间回写、无效文件跳过、软删除忽略等场景
- 更新版本号与 README / README_en 更新日志到 `2.4.1`

## 验证
- `dotnet test DesktopMemo.sln`
