### PR TITLE
Update core module comments and repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ DesktopMemo 是一个基于 .NET 9.0 + WPF + CommunityToolkit.Mvvm 的桌面便�
 
 ```bash
 # 克隆仓库
-git clone https://github.com/SaltedDoubao/DesktopMemo.git
+git clone https://github.com/SaltedCollection/DesktopMemo.git
 cd DesktopMemo
 ```
 
@@ -177,13 +177,13 @@ DesktopMemo_rebuild/
 
 ## 🤝 贡献者
 
-<a href="https://github.com/SaltedDoubao/DesktopMemo/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=SaltedDoubao/DesktopMemo" />
+<a href="https://github.com/SaltedCollection/DesktopMemo/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=SaltedCollection/DesktopMemo" />
 </a>
 
 ## 🌟 星标历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=SaltedDoubao/DesktopMemo&type=Date)](https://star-history.com/#SaltedDoubao/DesktopMemo&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=SaltedCollection/DesktopMemo&type=Date)](https://star-history.com/#SaltedCollection/DesktopMemo&Date)
 
 <div align="center">
 

--- a/README_en.md
+++ b/README_en.md
@@ -75,7 +75,7 @@ If you need to debug the project or participate in development, you can follow t
 
 ```bash
 # Clone repository
-git clone https://github.com/SaltedDoubao/DesktopMemo.git
+git clone https://github.com/SaltedCollection/DesktopMemo.git
 cd DesktopMemo
 ```
 
@@ -177,13 +177,13 @@ This project is licensed under the [MIT License](LICENSE).
 
 ## 🤝 Contributors
 
-<a href="https://github.com/SaltedDoubao/DesktopMemo/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=SaltedDoubao/DesktopMemo" />
+<a href="https://github.com/SaltedCollection/DesktopMemo/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=SaltedCollection/DesktopMemo" />
 </a>
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=SaltedDoubao/DesktopMemo&type=Date)](https://star-history.com/#SaltedDoubao/DesktopMemo&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=SaltedCollection/DesktopMemo&type=Date)](https://star-history.com/#SaltedCollection/DesktopMemo&Date)
 
 <div align="center">
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -49,7 +49,7 @@ git clone https://github.com/yourname/DesktopMemo.git
 cd DesktopMemo
 
 # 3. 添加上游仓库
-git remote add upstream https://github.com/SaltedDoubao/DesktopMemo.git
+git remote add upstream https://github.com/SaltedCollection/DesktopMemo.git
 ```
 
 ### 构建项目
@@ -649,8 +649,8 @@ A:
 
 感谢所有为 DesktopMemo 做出贡献的开发者！
 
-<a href="https://github.com/SaltedDoubao/DesktopMemo/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=SaltedDoubao/DesktopMemo" />
+<a href="https://github.com/SaltedCollection/DesktopMemo/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=SaltedCollection/DesktopMemo" />
 </a>
 
 ---

--- a/src/DesktopMemo.App/App.xaml.cs
+++ b/src/DesktopMemo.App/App.xaml.cs
@@ -12,6 +12,10 @@ using WpfApp = System.Windows.Application;
 
 namespace DesktopMemo.App;
 
+/// <summary>
+/// WPF 应用程序入口。
+/// 负责搭建依赖注入容器、执行启动迁移并创建主窗口。
+/// </summary>
 public partial class App : WpfApp
 {
     public IServiceProvider Services { get; }
@@ -21,6 +25,9 @@ public partial class App : WpfApp
         Services = ConfigureServices();
     }
 
+    /// <summary>
+    /// 注册应用运行所需的服务、仓储与 ViewModel。
+    /// </summary>
     private IServiceProvider ConfigureServices()
     {
         var appDirectory = AppContext.BaseDirectory;
@@ -28,7 +35,7 @@ public partial class App : WpfApp
 
         var services = new ServiceCollection();
 
-        // 核心服务
+        // 核心服务负责日志、数据持久化、检索与兼容旧版本数据。
         services.AddSingleton<ILogService>(_ => new FileLogService(dataDirectory));
         services.AddSingleton<IMemoRepository>(_ => new SqliteIndexedMemoRepository(dataDirectory));
         services.AddSingleton<ITodoRepository>(_ => new SqliteTodoRepository(dataDirectory));
@@ -36,21 +43,21 @@ public partial class App : WpfApp
         services.AddSingleton<IMemoSearchService, MemoSearchService>();
         services.AddSingleton(_ => new MemoMigrationService(dataDirectory, appDirectory));
         
-        // 数据迁移服务
+        // 启动阶段迁移服务按“待办 -> 备忘录索引 -> front matter 时间同步”的顺序执行。
         services.AddSingleton<TodoMigrationService>();
         services.AddSingleton<MemoMetadataMigrationService>();
         services.AddSingleton(_ => new MemoFrontMatterTimestampSyncService(
             dataDirectory,
             _.GetRequiredService<ILogService>()));
 
-        // 窗口和托盘服务
+        // 窗口和托盘服务与具体 UI 生命周期强相关，因此保持单例共享状态。
         services.AddSingleton<IWindowService, WindowService>();
         services.AddSingleton<ITrayService, TrayService>();
 
-        // 本地化服务
+        // 本地化服务在整个会话内共享当前语言状态。
         services.AddSingleton<ILocalizationService, LocalizationService>();
 
-        // ViewModel
+        // 主界面和子面板的 ViewModel 统一交给容器管理，便于跨窗口复用。
         services.AddSingleton<TodoListViewModel>();
         services.AddSingleton<LogViewModel>();
         services.AddSingleton<MainViewModel>();
@@ -64,11 +71,11 @@ public partial class App : WpfApp
 
         try
         {
-            // 执行数据迁移
+            // 启动时优先做数据兼容处理，避免 UI 加载后才发现旧数据结构无法读取。
             var appDirectory = AppContext.BaseDirectory;
             var dataDirectory = Path.Combine(appDirectory, ".memodata");
             
-            // 初始化日志服务
+            // 尽早初始化日志和全局异常处理，保证后续启动失败也能留下诊断信息。
             var logService = Services.GetRequiredService<ILogService>();
             RegisterGlobalExceptionHandlers(logService);
             logService.Info("App", "应用程序启动");
@@ -114,7 +121,7 @@ public partial class App : WpfApp
             System.Diagnostics.Debug.WriteLine("========== 数据迁移检查完成 ==========");
             logService.Info("Migration", "数据迁移检查完成");
 
-            // 加载语言设置
+            // 先恢复语言，再构建窗口，确保首帧 UI 就使用用户上次选择的文化。
             var settingsService = Services.GetRequiredService<ISettingsService>();
             var localizationService = Services.GetRequiredService<ILocalizationService>();
             
@@ -135,7 +142,7 @@ public partial class App : WpfApp
                 ws.Initialize(window);
             }
 
-            // 初始化托盘服务，但不要因为失败而停止应用程序
+            // 托盘是增强能力，不应因为初始化失败而阻止主窗口运行。
             try
             {
                 trayService.Initialize();
@@ -145,7 +152,7 @@ public partial class App : WpfApp
                 // 托盘服务初始化失败，但应用程序仍然可以运行
             }
 
-            // 在显示窗口之前先加载配置（配置中会根据设置决定是否显示托盘）
+            // 先初始化 ViewModel，再显示窗口，避免首帧出现“默认值闪一下”的情况。
             await viewModel.InitializeAsync();
 
             MainWindow = window;
@@ -165,6 +172,9 @@ public partial class App : WpfApp
         }
     }
 
+    /// <summary>
+    /// 注册全局异常处理器，尽量把前台和后台异常都收敛到统一日志中。
+    /// </summary>
     private void RegisterGlobalExceptionHandlers(ILogService logService)
     {
         AppDomain.CurrentDomain.UnhandledException += (s, e) =>
@@ -176,7 +186,7 @@ public partial class App : WpfApp
         DispatcherUnhandledException += (s, e) =>
         {
             logService.Error("App", "UI线程未处理异常", e.Exception);
-            e.Handled = true; // 关键：防止应用崩溃
+            e.Handled = true; // 关键：防止 UI 线程异常直接导致进程退出。
 
             // 显示友好的错误提示
             System.Windows.MessageBox.Show(
@@ -200,7 +210,7 @@ public partial class App : WpfApp
         
         Services.GetService<ITrayService>()?.Dispose();
         
-        // 释放日志服务（等待文件写入完成）
+        // 日志服务最后释放，尽量保证退出前的收尾日志能落盘。
         if (logService is IDisposable disposableLog)
         {
             disposableLog.Dispose();

--- a/src/DesktopMemo.App/Localization/LocalizationService.cs
+++ b/src/DesktopMemo.App/Localization/LocalizationService.cs
@@ -6,14 +6,15 @@ using DesktopMemo.Core.Contracts;
 namespace DesktopMemo.App.Localization;
 
 /// <summary>
-/// 本地化服务实现，支持运行时动态切换语言
+/// 本地化服务实现，支持运行时动态切换语言。
+/// 通过索引器暴露资源字符串，便于 XAML 和 ViewModel 统一访问。
 /// </summary>
 public class LocalizationService : ILocalizationService, INotifyPropertyChanged
 {
     private readonly ResourceManager _resourceManager;
     private CultureInfo _currentCulture;
     
-    // 支持的语言列表
+    // 支持的语言列表固定在客户端内，避免用户选择到没有资源文件的文化。
     private static readonly CultureInfo[] SupportedCultures = new[]
     {
         new CultureInfo("zh-CN"), // 简体中文
@@ -25,13 +26,13 @@ public class LocalizationService : ILocalizationService, INotifyPropertyChanged
 
     public LocalizationService()
     {
-        // 初始化资源管理器，指向 Strings 资源文件
+        // ResourceManager 统一管理多语言 resx 资源。
         _resourceManager = new ResourceManager(
             "DesktopMemo.App.Localization.Resources.Strings",
             typeof(LocalizationService).Assembly
         );
         
-        // 默认使用简体中文
+        // 默认文化与项目主要受众一致，首次启动无需依赖设置文件。
         _currentCulture = new CultureInfo("zh-CN");
     }
 
@@ -46,7 +47,7 @@ public class LocalizationService : ILocalizationService, INotifyPropertyChanged
             {
                 var value = _resourceManager.GetString(key, _currentCulture);
                 
-                // 如果找不到资源，返回键名作为后备
+                // 用 [key] 作为兜底，能让缺失翻译在 UI 中一眼暴露。
                 return value ?? $"[{key}]";
             }
             catch
@@ -56,7 +57,7 @@ public class LocalizationService : ILocalizationService, INotifyPropertyChanged
         }
         set
         {
-            // Ignore accidental TwoWay bindings targeting localization resources.
+            // 忽略误绑定到 TwoWay 的写入请求；本地化资源只读。
         }
     }
 
@@ -73,17 +74,17 @@ public class LocalizationService : ILocalizationService, INotifyPropertyChanged
                 var oldCulture = _currentCulture;
                 _currentCulture = value;
                 
-                // 更新线程的 UI 文化
+                // 同步线程文化，确保日期、数字和资源查找都切到新语言。
                 Thread.CurrentThread.CurrentUICulture = value;
                 Thread.CurrentThread.CurrentCulture = value;
                 
-                // 触发属性变更通知
+                // 绑定到 CurrentCulture 的下拉框等控件需要收到属性变更。
                 OnPropertyChanged(nameof(CurrentCulture));
                 
-                // 通知所有资源键的值可能已改变
+                // 索引器绑定使用 Item[] 通知，让所有本地化文本整体刷新。
                 OnPropertyChanged("Item[]");
                 
-                // 触发语言切换事件
+                // 额外抛事件给需要做二次处理的组件，例如托盘菜单或组合文案。
                 LanguageChanged?.Invoke(this, new LanguageChangedEventArgs(value, oldCulture));
             }
         }
@@ -98,7 +99,7 @@ public class LocalizationService : ILocalizationService, INotifyPropertyChanged
         {
             var newCulture = new CultureInfo(cultureName);
             
-            // 验证是否为支持的语言
+            // 只允许切换到显式支持的文化，避免资源缺失造成半翻译状态。
             if (!SupportedCultures.Any(c => c.Name == newCulture.Name))
             {
                 throw new CultureNotFoundException(
@@ -111,7 +112,7 @@ public class LocalizationService : ILocalizationService, INotifyPropertyChanged
         }
         catch (CultureNotFoundException)
         {
-            // 如果文化名称无效，回退到默认中文
+            // 非法文化或不支持的语言都回退到默认中文。
             CurrentCulture = new CultureInfo("zh-CN");
         }
     }

--- a/src/DesktopMemo.App/MainWindow.xaml.cs
+++ b/src/DesktopMemo.App/MainWindow.xaml.cs
@@ -17,6 +17,10 @@ using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 
 namespace DesktopMemo.App;
 
+/// <summary>
+/// 主窗口代码隐藏层。
+/// 负责承接 WPF 事件、协调 View 与 ViewModel 之间的瞬时交互，以及处理窗口级生命周期。
+/// </summary>
 public partial class MainWindow : Window
 {
     private readonly MainViewModel _viewModel;
@@ -24,8 +28,8 @@ public partial class MainWindow : Window
     private readonly ITrayService _trayService;
     private readonly ILogService _logService;
     private bool _isClosing = false;
-    private SettingsWindow? _settingsWindow; // 单例字段
-    private bool _isOpeningSettings = false; // 防止并发打开设置窗口
+    private SettingsWindow? _settingsWindow; // 维持设置窗口单实例，避免重复打开造成状态分裂。
+    private bool _isOpeningSettings = false; // 防止短时间内重复点击触发并发打开。
 
     public MainWindow(MainViewModel viewModel, IWindowService windowService, ITrayService trayService, ILogService logService)
     {
@@ -61,16 +65,22 @@ public partial class MainWindow : Window
         }
     }
 
+    /// <summary>
+    /// 配置窗口首次加载时的层级与动画行为。
+    /// </summary>
     private void ConfigureWindow()
     {
         Loaded += (s, e) =>
         {
-            // 按当前用户选择的置顶模式应用，而非强制 Desktop
+            // 按用户恢复的模式应用窗口层级，而不是写死默认值。
             _windowService.SetTopmostMode(_viewModel.SelectedTopmostMode);
             _windowService.PlayFadeInAnimation();
         };
     }
 
+    /// <summary>
+    /// 把托盘菜单事件映射到 ViewModel 命令或窗口行为。
+    /// </summary>
     private void ConfigureTrayService()
     {
         _trayService.TrayIconDoubleClick += (s, e) => _windowService.ToggleWindowVisibility();
@@ -115,6 +125,9 @@ public partial class MainWindow : Window
         OpenSettingsWindow();
     }
 
+    /// <summary>
+    /// 打开或激活设置窗口，确保整个应用只有一个设置窗口实例。
+    /// </summary>
     private void OpenSettingsWindow()
     {
         if (!Dispatcher.CheckAccess())
@@ -123,7 +136,7 @@ public partial class MainWindow : Window
             return;
         }
 
-        // 防止并发打开
+        // 用户连续点击托盘或按钮时，这个保护可以避免创建出多个实例。
         if (_isOpeningSettings)
         {
             _logService.Debug("Settings", "设置窗口正在打开中，忽略重复请求");
@@ -136,13 +149,12 @@ public partial class MainWindow : Window
             _logService.Info("Settings", "请求打开设置窗口");
             _viewModel.IsSettingsPanelVisible = false;
 
-            // 检查现有窗口是否可用
+            // 如果旧窗口还活着，就直接激活它，而不是新建。
             if (_settingsWindow != null)
             {
                 try
                 {
-                    // 关键改进：检查 IsVisible 而非 IsLoaded
-                    // IsVisible 在窗口关闭时会立即变为 false
+                    // 这里看 IsVisible 而不是 IsLoaded，因为窗口关闭过程中后者可能仍为 true。
                     if (_settingsWindow.IsVisible && _settingsWindow.WindowState != WindowState.Minimized)
                     {
                         _logService.Debug("Settings", "激活现有设置窗口");
@@ -162,7 +174,7 @@ public partial class MainWindow : Window
                     }
                     else
                     {
-                        // 窗口不可见，说明正在关闭或已关闭
+                        // 不可见说明窗口已经进入关闭流程，直接丢弃引用创建新实例。
                         _logService.Debug("Settings", "现有窗口不可见，将创建新实例");
                         _settingsWindow = null;
                     }
@@ -174,11 +186,11 @@ public partial class MainWindow : Window
                 }
             }
 
-            // 创建新窗口
+            // 仅在无法复用旧窗口时才创建新实例。
             _logService.Info("Settings", "创建新的设置窗口");
             var newWindow = new SettingsWindow(_viewModel);
 
-            // 关键改进：在 Closing 事件中立即清空引用
+            // 在 Closing 阶段就释放引用，避免窗口尚未 Closed 时阻塞下一次打开。
             newWindow.Closing += (s, e) =>
             {
                 _logService.Debug("Settings", "设置窗口开始关闭，立即清空引用");
@@ -188,7 +200,7 @@ public partial class MainWindow : Window
                 }
             };
 
-            // 保留 Closed 事件用于日志记录
+            // Closed 事件仅保留日志，用于区分“开始关闭”和“完全关闭”。
             newWindow.Closed += (s, e) =>
             {
                 _logService.Debug("Settings", "设置窗口已完全关闭");
@@ -209,7 +221,7 @@ public partial class MainWindow : Window
         }
         finally
         {
-            // 延迟重置标志，防止过快的连续点击
+            // 延后一拍重置标志，减少极短时间内重入。
             Dispatcher.BeginInvoke(new Action(() =>
             {
                 _isOpeningSettings = false;
@@ -217,6 +229,9 @@ public partial class MainWindow : Window
         }
     }
 
+    /// <summary>
+    /// 把主窗口的关键状态同步给设置窗口。
+    /// </summary>
     private void ApplySettingsWindowState(SettingsWindow settingsWindow)
     {
         settingsWindow.Topmost = _viewModel.SelectedTopmostMode == TopmostMode.Always;
@@ -239,6 +254,9 @@ public partial class MainWindow : Window
         }
     }
 
+    /// <summary>
+    /// 控制右侧快捷设置面板的显隐与动画。
+    /// </summary>
     private void ApplyQuickSettingsVisibility(bool show)
     {
         if (show)
@@ -252,6 +270,9 @@ public partial class MainWindow : Window
         }
     }
 
+    /// <summary>
+    /// 通过平移动画切换快捷设置面板，保持面板进出的一致手感。
+    /// </summary>
     private void AnimateQuickSettingsPanel(bool show)
     {
         if (QuickSettingsPanel.RenderTransform is not System.Windows.Media.TranslateTransform transform)
@@ -284,11 +305,11 @@ public partial class MainWindow : Window
         Loaded -= OnLoaded;
         try
         {
-            // 配置已在 App.OnStartup 中加载，这里只需要应用UI状态
+            // 设置与数据已在 App 启动阶段恢复，这里只负责把状态映射到视觉层。
             ApplyQuickSettingsVisibility(_viewModel.IsSettingsPanelVisible);
             ApplyWindowSize(_viewModel.WindowSettings);
             
-            // 应用初始主题
+            // 首次加载时主动套一次主题，避免资源字典停留在默认态。
             ApplyTheme(_viewModel.SelectedTheme);
         }
         catch (Exception ex)
@@ -297,7 +318,7 @@ public partial class MainWindow : Window
                 "DesktopMemo 初始化错误",
                 MessageBoxButton.OK, MessageBoxImage.Error);
             
-            // 尝试使用默认设置继续运行
+            // 出错时尽量降级运行，避免一次初始化异常直接让应用不可用。
             try
             {
                 ApplyQuickSettingsVisibility(false);
@@ -320,7 +341,7 @@ public partial class MainWindow : Window
     {
         var actualTheme = theme;
 
-        // 如果选择了跟随系统，检测系统主题
+        // “跟随系统”只是运行时策略，真正加载的仍然是 Light/Dark 资源字典。
         if (theme == AppTheme.System)
         {
             actualTheme = IsSystemDarkMode() ? AppTheme.Dark : AppTheme.Light;
@@ -328,7 +349,7 @@ public partial class MainWindow : Window
 
         try
         {
-            // 构建主题资源 URI
+            // 主题资源字典按文件切换，避免在单个大字典里维护过多条件分支。
             var themeFileName = actualTheme == AppTheme.Dark
                 ? "Dark.xaml"
                 : "Light.xaml";
@@ -337,14 +358,14 @@ public partial class MainWindow : Window
                 $"Resources/Themes/{themeFileName}",
                 UriKind.Relative);
 
-            // 先创建并加载新的资源字典
+            // 先插入新字典再移除旧字典，可减少切换瞬间资源缺失导致的闪烁。
             var newThemeDict = new ResourceDictionary { Source = themeUri };
 
-            // 找到旧的主题字典
+            // 只替换 Themes 目录下的那一本主题字典，其他资源保持不动。
             var oldThemeDict = System.Windows.Application.Current.Resources.MergedDictionaries
                 .FirstOrDefault(d => d.Source != null && d.Source.OriginalString.Contains("Themes/"));
 
-            // 原子性替换：先插入新字典，再移除旧字典
+            // 原子性替换：先插入新字典，再移除旧字典。
             System.Windows.Application.Current.Resources.MergedDictionaries.Insert(0, newThemeDict);
 
             if (oldThemeDict != null)
@@ -357,11 +378,11 @@ public partial class MainWindow : Window
         catch (Exception ex)
         {
             _logService?.Error("Theme", "主题切换失败", ex);
-            // 主题切换失败不影响应用程序继续运行
+            // 主题只是表现层能力，失败时不能影响主功能。
             return;
         }
 
-        // 更新滑块样式
+        // 主题切换后，部分控件样式需要重新按键名取一次资源。
         try
         {
             if (BackgroundOpacitySlider != null)
@@ -407,7 +428,7 @@ public partial class MainWindow : Window
 
     private void OnLocationChanged(object? sender, EventArgs e)
     {
-        // 实时更新位置显示
+        // 位置变更用于更新设置面板上的只读坐标展示。
         _viewModel.UpdateCurrentPosition();
     }
 
@@ -465,7 +486,7 @@ public partial class MainWindow : Window
 
     private async void CloseButton_Click(object sender, RoutedEventArgs e)
     {
-        // 防止并发调用
+        // 关闭按钮可能被多次点击，这里做串行保护。
         if (_isClosing)
         {
             return;
@@ -478,10 +499,10 @@ public partial class MainWindow : Window
         }
         catch (Exception ex)
         {
-            // 记录异常到日志服务
+            // 关闭流程里牵涉对话框、托盘和持久化，异常需要尽量完整记录。
             _logService.Error("MainWindow", $"处理关闭按钮异常: {ex.Message}", ex);
 
-            // 如果异步处理失败，回退到UI线程执行默认关闭行为
+            // 主关闭流程失败后，回退到尽可能简单的默认行为。
             try
             {
                 if (_viewModel.WindowSettings.DefaultExitToTray)
@@ -496,7 +517,7 @@ public partial class MainWindow : Window
             catch (Exception fallbackEx)
             {
                 _logService.Error("MainWindow", $"回退关闭失败: {fallbackEx.Message}", fallbackEx);
-                // 最后的安全措施
+                // 最后的兜底，避免进程卡在半关闭状态。
                 Environment.Exit(0);
             }
         }
@@ -508,7 +529,7 @@ public partial class MainWindow : Window
 
     private async Task HandleCloseButtonClickAsync()
     {
-        // 首先检查是否有未保存的编辑
+        // 关闭流程优先处理未保存内容，其次再处理“退出还是最小化到托盘”。
         if (_viewModel.IsEditMode && _viewModel.IsContentModified)
         {
             Views.UnsavedChangesDialog? unsavedDialog = null;
@@ -533,7 +554,7 @@ public partial class MainWindow : Window
 
             if (unsavedResult != true || unsavedDialog == null)
             {
-                // 对话框创建失败或关闭，取消关闭操作
+                // 对话框失败时宁可取消关闭，也不要冒险丢失用户编辑内容。
                 return;
             }
 
@@ -545,7 +566,7 @@ public partial class MainWindow : Window
                 case Views.UnsavedChangesAction.Cancel:
                     return; // 取消关闭
                 case Views.UnsavedChangesAction.Discard:
-                    // 恢复编辑内容，防止后续操作保存修改
+                    // 丢弃修改时把编辑器恢复到已保存版本，避免后续流程误保存脏内容。
                     _viewModel.EditorContent = _viewModel.SelectedMemo?.Content ?? string.Empty;
                     break; // 继续关闭流程
             }
@@ -557,7 +578,7 @@ public partial class MainWindow : Window
             Views.ExitConfirmationDialog? dialog = null;
             bool? result = null;
 
-            // 在UI线程上创建和显示对话框
+            // 退出确认框需要在 UI 线程创建，确保 Owner 与模态行为正常。
             await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
             {
                 try
@@ -582,10 +603,10 @@ public partial class MainWindow : Window
 
             if (result != true || dialog == null)
             {
-                // 用户取消或对话框创建失败
+                // 用户取消时直接中止；若对话框失败，则回退到默认关闭策略。
                 if (result == null)
                 {
-                    // 对话框创建失败，使用默认行为
+                    // 对话框异常时，仍按已保存偏好执行默认动作。
                     await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
                     {
                         if (_viewModel.WindowSettings.DefaultExitToTray)
@@ -601,10 +622,9 @@ public partial class MainWindow : Window
                 return;
             }
 
-            // 如果用户选择了"不再显示"，立即更新内存中的设置，然后异步保存
+            // “不再显示”要先更新内存，防止后续其他设置保存把这次选择覆盖掉。
             if (dialog.DontShowAgain)
             {
-                // 立即更新内存中的设置，避免被后续的设置保存覆盖
                 bool exitToTray = dialog.Action == Views.ExitAction.MinimizeToTray;
                 var newSettings = _viewModel.WindowSettings with
                 {
@@ -613,7 +633,7 @@ public partial class MainWindow : Window
                 };
                 _viewModel.WindowSettings = newSettings;
 
-                // 异步保存到磁盘（不等待，避免阻塞退出操作）
+                // 退出动作优先，不等待设置保存完成。
                 _ = Task.Run(async () =>
                 {
                     try
@@ -624,12 +644,12 @@ public partial class MainWindow : Window
                     catch (Exception ex)
                     {
                         System.Diagnostics.Debug.WriteLine($"保存退出设置失败: {ex}");
-                        // 设置保存失败不影响退出操作
+                        // 设置保存失败不影响退出动作本身。
                     }
                 });
             }
 
-            // 在UI线程执行退出操作
+            // 最终的窗口隐藏或进程退出必须回到 UI 线程执行。
             await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
             {
                 switch (dialog.Action)
@@ -651,7 +671,7 @@ public partial class MainWindow : Window
         }
         else
         {
-            // 不显示确认，根据保存的设置执行默认行为
+            // 已关闭确认框时，直接走持久化的默认退出策略。
             await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
             {
                 if (_viewModel.WindowSettings.DefaultExitToTray)
@@ -674,8 +694,7 @@ public partial class MainWindow : Window
 
     private void NoteTextBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
     {
-        // 仅标记编辑状态，不触发自动保存
-        // 用户需要手动保存（Ctrl+S 或点击保存按钮）
+        // 编辑器变更只更新“脏状态”，项目当前仍坚持显式保存。
         _viewModel.MarkEditing();
     }
 
@@ -762,13 +781,13 @@ public partial class MainWindow : Window
 
     private void ShowFindDialog()
     {
-        // 实现查找对话框或内联查找功能
+        // 当前先给出状态提示，后续可替换为真正的查找面板。
         _viewModel.SetStatus("查找功能 - 使用 F3 查找下一个");
     }
 
     private void ShowReplaceDialog()
     {
-        // 实现替换对话框或内联替换功能
+        // 当前先给出状态提示，后续可替换为真正的替换面板。
         _viewModel.SetStatus("替换功能 - 使用 Ctrl+H 替换");
     }
 
@@ -812,7 +831,7 @@ public partial class MainWindow : Window
         var caretIndex = textBox.CaretIndex;
         var text = textBox.Text;
 
-        // 找到当前行的开始和结束
+        // 基于换行符定位当前逻辑行，然后把整行文本复制到下一行。
         var lineStart = text.LastIndexOf('\n', Math.Max(0, caretIndex - 1)) + 1;
         var lineEnd = text.IndexOf('\n', caretIndex);
         if (lineEnd == -1) lineEnd = text.Length;
@@ -842,7 +861,7 @@ public partial class MainWindow : Window
         var caretIndex = textBox.CaretIndex;
         var text = textBox.Text;
 
-        // 找到当前行开始
+        // 对整行统一增加 4 空格缩进，符合 Markdown 常见缩进约定。
         var lineStart = text.LastIndexOf('\n', Math.Max(0, caretIndex - 1)) + 1;
         textBox.Text = text.Insert(lineStart, "    ");
         textBox.CaretIndex = caretIndex + 4;
@@ -856,10 +875,10 @@ public partial class MainWindow : Window
         var caretIndex = textBox.CaretIndex;
         var text = textBox.Text;
 
-        // 找到当前行开始
+        // 仅处理当前行开头的缩进，不试图做复杂的多行反缩进。
         var lineStart = text.LastIndexOf('\n', Math.Max(0, caretIndex - 1)) + 1;
 
-        // 检查是否有缩进可以删除
+        // 优先删除一个标准缩进宽度，其次退化为删除单个空格。
         if (lineStart < text.Length && text.Substring(lineStart, Math.Min(4, text.Length - lineStart)) == "    ")
         {
             textBox.Text = text.Remove(lineStart, 4);
@@ -894,7 +913,7 @@ public partial class MainWindow : Window
     {
         if (MainContainer != null)
         {
-            // 创建新的背景画刷
+            // 当前窗口背景透明度通过重新生成画刷来表达。
             var backgroundColor = System.Windows.Media.Color.FromArgb(
                 (byte)(255 * opacity), // Alpha通道
                 255, 255, 255); // RGB白色
@@ -922,7 +941,7 @@ public partial class MainWindow : Window
     /// </summary>
     private void EditTodoTextBox_LostFocus(object sender, RoutedEventArgs e)
     {
-        // 延迟执行以避免与保存命令冲突
+        // 延迟到后台优先级，避免与回车保存或点击保存按钮互相抢焦点。
         Dispatcher.BeginInvoke(new Action(() =>
         {
             if (_viewModel?.TodoListViewModel?.EditingTodoId != null)
@@ -965,7 +984,7 @@ public partial class MainWindow : Window
         if (!_viewModel.TodoListViewModel.IsInputVisible)
             return;
 
-        // 检查点击位置是否在输入区域外
+        // 点击区域不在输入框容器内时，视为用户结束了本次临时输入。
         if (TodoInputBorder != null && !TodoInputBorder.IsMouseOver)
         {
             _viewModel.TodoListViewModel.OnInputLostFocus();

--- a/src/DesktopMemo.App/ViewModels/MainViewModel.cs
+++ b/src/DesktopMemo.App/ViewModels/MainViewModel.cs
@@ -18,6 +18,10 @@ using System.IO;
 
 namespace DesktopMemo.App.ViewModels;
 
+/// <summary>
+/// 应用主视图模型。
+/// 负责协调备忘录编辑、待办模式切换、窗口设置、托盘交互以及本地化状态。
+/// </summary>
 public partial class MainViewModel : ObservableObject, IDisposable
 {
     private readonly IMemoRepository _memoRepository;
@@ -30,6 +34,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private readonly ILocalizationService _localizationService;
     private readonly ILogService _logService;
     private readonly LogViewModel _logViewModel;
+    // 高频设置变更统一走防抖保存，避免拖拽窗口或快速切换选项时持续刷盘。
     private readonly DebounceHelper _settingsSaveDebouncer;
 
     [ObservableProperty]
@@ -118,6 +123,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     private bool _isDisposing;
     private bool _isInitializing;
+
+    // 进入编辑模式时记录初始正文，用于判断是否存在未保存修改。
     private string? _originalContent;
 
     [ObservableProperty]
@@ -179,6 +186,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         InitializeAppInfo();
     }
 
+    /// <summary>
+    /// 启动时恢复设置、加载数据并初始化托盘与待办视图。
+    /// </summary>
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
         _isInitializing = true;
@@ -205,6 +215,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         Memos = new ObservableCollection<Memo>(memos.OrderByDescending(m => m.UpdatedAt));
 
+        // 默认选中最新一条备忘录，让编辑区在启动后马上可用。
         SelectedMemo = Memos.FirstOrDefault();
         if (SelectedMemo is not null)
         {
@@ -226,7 +237,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             _trayService.Hide();
         }
 
-        // 初始化 TodoListViewModel
+        // 待办子视图模型在主流程中统一初始化，保证页面切换时状态已就绪。
         await _todoListViewModel.InitializeAsync(cancellationToken);
 
         // 初始化选择的语言
@@ -238,7 +249,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // 初始化托盘菜单文本
         _trayService.UpdateMenuTexts(key => _localizationService[key]);
 
-        // 恢复上次的页面状态
+        // 恢复“备忘录页 / 待办页”停留位置，减少重启后的上下文丢失。
         if (settings.CurrentPage == "todo")
         {
             IsInTodoListMode = true;
@@ -252,12 +263,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _trayService.UpdateTopmostState(SelectedTopmostMode);
         _trayService.UpdateClickThroughState(IsClickThroughEnabled);
 
-        // 检查开机自启动状态
+        // 自启动状态依赖注册表，需要在 UI 与服务初始化后补查。
         CheckAutoStartStatus();
         
         _isInitializing = false;
     }
 
+    /// <summary>
+    /// 把持久化设置映射为当前运行态，并同步到底层窗口服务。
+    /// </summary>
     private void ApplyWindowSettings(WindowSettings settings)
     {
         WindowSettings = settings;
@@ -271,7 +285,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             _windowService.SetWindowPosition(settings.Left, settings.Top);
         }
 
-        // 确保透明度值在合理范围内
+        // 设置文件可能来自旧版本或被用户手工修改，需要先做归一化。
         var transparencyValue = TransparencyHelper.NormalizeTransparency(settings.Transparency);
         System.Diagnostics.Debug.WriteLine($"设置加载: 原始透明度={settings.Transparency}, 规范化后={transparencyValue}");
 
@@ -284,11 +298,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         SelectedTopmostMode = _windowService.GetCurrentTopmostMode();
 
-        // 从窗口服务获取实际设置的透明度值
+        // 再次读取窗口服务中的实际值，确保 ViewModel 和底层服务状态一致。
         var actualOpacity = _windowService.GetWindowOpacity();
         BackgroundOpacity = actualOpacity;
 
-        // 使用统一的透明度转换逻辑，并确保百分比值有效
+        // 百分比是 UI 展示值，真实透明度仍以 0~MAX_TRANSPARENCY 的值保存。
         var calculatedPercent = TransparencyHelper.ToPercent(actualOpacity);
         BackgroundOpacityPercent = double.IsNaN(calculatedPercent) ? 0.0 : calculatedPercent;
 
@@ -296,7 +310,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         
         IsClickThroughEnabled = _windowService.IsClickThroughEnabled;
         
-        // 恢复窗口固定状态
+        // 固定状态只影响界面行为，由 ViewModel 维护并持久化。
         System.Diagnostics.Debug.WriteLine($"[ApplyWindowSettings] 恢复窗口固定状态: {settings.IsWindowPinned}");
         IsWindowPinned = settings.IsWindowPinned;
         
@@ -320,6 +334,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         SetStatus($"透明度已调整为 {(int)percent}%");
     }
 
+    /// <summary>
+    /// 主窗口尺寸变化时更新内存设置，并在高频变化场景下延迟保存。
+    /// </summary>
     public void UpdateMainWindowSize(double width, double height, bool immediateSave = false)
     {
         if (_isInitializing)
@@ -347,6 +364,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         });
     }
 
+    /// <summary>
+    /// 设置窗口移动或缩放后同步边界信息。
+    /// </summary>
     public void UpdateSettingsWindowBounds(double width, double height, double left, double top, bool immediateSave = false)
     {
         if (_isInitializing)
@@ -391,6 +411,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         var memo = Memo.CreateNew(_localizationService["Memo_NewTitle"], string.Empty);
         await _memoRepository.AddAsync(memo);
 
+        // 新建后直接切换到编辑态，符合便签工具“即建即写”的使用预期。
         Memos.Insert(0, memo);
         SelectedMemo = memo;
         EditorTitle = memo.Title;
@@ -409,6 +430,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             return;
         }
 
+        // 内容和元数据采用不可变 record 链式更新，保证修改轨迹清晰。
         var updated = SelectedMemo
             .WithContent(EditorContent, DateTimeOffset.Now)
             .WithMetadata(EditorTitle, SelectedMemo.Tags, SelectedMemo.IsPinned, DateTimeOffset.Now);
@@ -422,6 +444,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             SelectedMemo = updated;
         }
 
+        // 保存成功后重置“脏状态”基线。
         _originalContent = EditorContent;
         IsContentModified = false;
 
@@ -438,13 +461,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
             return;
         }
 
-        // 检查是否需要显示确认框
+        // 删除确认由设置控制；真正删除前先在 UI 线程显示对话框。
         if (WindowSettings.ShowDeleteConfirmation)
         {
             Views.ConfirmationDialog? dialog = null;
             bool? result = null;
 
-            // 在UI线程上显示对话框
+            // 对话框必须在 UI 线程创建和显示，否则 WPF Owner 关系会不稳定。
             try
             {
                 await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
@@ -454,7 +477,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                         _localizationService["Dialog_DeleteConfirm_Title"],
                         string.Format(_localizationService["Dialog_DeleteConfirm_Message"], SelectedMemo.DisplayTitle));
 
-                    // 安全地设置Owner
+                    // Owner 仅在主窗口已加载时设置，避免 ShowDialog 因窗口状态异常抛错。
                     if (System.Windows.Application.Current.MainWindow != null &&
                         System.Windows.Application.Current.MainWindow.IsLoaded)
                     {
@@ -503,14 +526,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 return;
             }
 
-            // 如果用户选择了"不再显示"，立即更新内存中的设置，然后异步保存
+            // “不再显示”需要立即落到内存，避免后续其他设置保存把它覆盖回去。
             if (dialog.DontShowAgain)
             {
-                // 立即更新内存中的设置，避免被后续的设置保存覆盖
                 var newSettings = WindowSettings with { ShowDeleteConfirmation = false };
                 WindowSettings = newSettings;
 
-                // 异步保存到磁盘（不等待，避免阻塞删除操作）
+                // 删除动作不应被设置保存阻塞，因此这里 fire-and-forget。
                 _ = Task.Run(async () =>
                 {
                     try
@@ -520,14 +542,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     }
                     catch (Exception ex)
                     {
-                        // 记录错误但不影响删除操作
+                        // 删除已获用户确认，设置保存失败不应反向阻断删除流程。
                         System.Diagnostics.Debug.WriteLine($"保存删除设置失败: {ex}");
                     }
                 });
             }
         }
 
-        // 执行删除操作
+        // 仓储层是软删除；UI 层则把当前项从可见集合中移除。
         var deleting = SelectedMemo;
         _logService.Info("Memo", $"删除备忘录: {deleting.Title}");
         await _memoRepository.DeleteAsync(deleting.Id);
@@ -557,7 +579,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         IsSettingsPanelVisible = !IsSettingsPanelVisible;
         if (IsSettingsPanelVisible)
         {
-            IsLogPanelVisible = false; // 关闭日志面板
+            IsLogPanelVisible = false; // 设置与日志面板互斥，避免右侧空间冲突。
         }
         SetStatus(IsSettingsPanelVisible ? "打开设置" : "关闭设置");
     }
@@ -1116,7 +1138,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// </summary>
     public void SetStatus(string status, LogLevel logLevel = LogLevel.Info)
     {
-        // 记录到日志系统
+        // 所有用户可感知状态都统一进日志，便于问题排查和后续日志面板展示。
         switch (logLevel)
         {
             case LogLevel.Debug:
@@ -1133,7 +1155,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 break;
         }
         
-        // 更新托盘图标文本（仅显示重要信息）
+        // 托盘文本只同步信息级别及以上状态，避免调试日志刷屏。
         if (logLevel >= LogLevel.Info)
         {
             _trayService.UpdateText($"DesktopMemo - {status}");
@@ -1152,13 +1174,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     private void OnLanguageChanged(object? sender, LanguageChangedEventArgs e)
     {
-        // 通知 UI 刷新所有本地化文本
+        // 索引器式本地化绑定需要主动触发属性变更，UI 才会重新取值。
         OnPropertyChanged(nameof(LocalizationService));
-        
-        // 更新应用信息（使用新语言）
+
+        // 依赖本地化字符串的组合文本都需要重新生成。
         InitializeAppInfo();
-        
-        // 更新托盘菜单文本
+
         _trayService.UpdateMenuTexts(key => _localizationService[key]);
     }
 
@@ -1166,13 +1187,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         if (value != null && value.Name != _localizationService.CurrentCulture.Name)
         {
-            // 切换语言
+            // 先切运行时语言，再异步持久化，确保界面响应优先。
             _localizationService.ChangeLanguage(value.Name);
-            
-            // 更新内存中的设置
+
             WindowSettings = WindowSettings with { PreferredLanguage = value.Name };
-            
-            // 保存到设置（异步）
+
             _ = Task.Run(async () =>
             {
                 try
@@ -1196,10 +1215,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         if (!_isInitializing)
         {
-            // 更新内存中的设置
+            // 主题切换同样采用“先生效、后持久化”的策略。
             WindowSettings = WindowSettings with { Theme = value };
-            
-            // 保存到设置（异步）
+
             _ = Task.Run(async () =>
             {
                 try
@@ -1224,7 +1242,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             _logService.Info("Settings", $"切换主题到 {themeName}");
             SetStatus($"主题已切换到 {themeName}");
             
-            // 触发主题变更事件，让MainWindow更新UI
+            // MainWindow 需要额外处理资源字典切换，因此通过事件通知 View。
             ThemeChanged?.Invoke(this, value);
         }
     }
@@ -1287,13 +1305,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     partial void OnIsInTodoListModeChanged(bool value)
     {
-        // 初始化期间不保存设置，避免覆盖刚加载的设置
+        // 初始化阶段只是回放历史状态，不应立刻覆盖磁盘中的原值。
         if (_isInitializing)
         {
             return;
         }
         
-        // 保存当前页面状态
         var currentPage = value ? "todo" : "memo";
         if (WindowSettings.CurrentPage == currentPage)
         {
@@ -1302,7 +1319,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         WindowSettings = WindowSettings with { CurrentPage = currentPage };
         
-        // 异步保存到设置
+        // 页面切换不需要阻塞 UI，直接异步保存即可。
         _ = Task.Run(async () =>
         {
             try
@@ -1319,10 +1336,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     private void OnTodoInputVisibilityChanged(object? sender, bool isVisible)
     {
-        // 更新设置
+        // 待办输入框可见性属于用户偏好，由主视图模型统一纳入设置。
         WindowSettings = WindowSettings with { TodoInputVisible = isVisible };
-        
-        // 异步保存到设置
+
         _ = Task.Run(async () =>
         {
             try
@@ -1341,19 +1357,17 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         System.Diagnostics.Debug.WriteLine($"[OnIsWindowPinnedChanged] 被触发: value={value}, _isInitializing={_isInitializing}");
         
-        // 初始化期间不保存设置，避免覆盖刚加载的设置
+        // 初始化阶段只是回放历史状态，不应立刻覆盖磁盘中的原值。
         if (_isInitializing)
         {
             System.Diagnostics.Debug.WriteLine($"[OnIsWindowPinnedChanged] 初始化期间，跳过保存");
             return;
         }
         
-        // 更新内存中的设置
         var oldSettings = WindowSettings;
         WindowSettings = WindowSettings with { IsWindowPinned = value };
         System.Diagnostics.Debug.WriteLine($"[OnIsWindowPinnedChanged] 更新设置: {oldSettings.IsWindowPinned} -> {WindowSettings.IsWindowPinned}");
         
-        // 异步保存到设置
         _ = Task.Run(async () =>
         {
             try
@@ -1380,6 +1394,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _disposed = true;
         _isDisposing = true;
 
+        // 释放顺序上先隐藏托盘再释放其资源，避免图标残留。
         if (IsTrayEnabled)
         {
             _trayService.Hide();

--- a/src/DesktopMemo.App/ViewModels/TodoListViewModel.cs
+++ b/src/DesktopMemo.App/ViewModels/TodoListViewModel.cs
@@ -12,6 +12,7 @@ namespace DesktopMemo.App.ViewModels;
 
 /// <summary>
 /// 待办事项列表的视图模型。
+/// 负责把仓储中的 Todo 数据拆成“未完成”和“已完成”两个集合，便于界面直接绑定。
 /// </summary>
 public partial class TodoListViewModel : ObservableObject
 {
@@ -33,7 +34,9 @@ public partial class TodoListViewModel : ObservableObject
     [ObservableProperty]
     private bool _isInputVisible = false;
 
-    // 编辑状态
+    /// <summary>
+    /// 当前处于内联编辑状态的待办项 ID；为空表示没有项目正在编辑。
+    /// </summary>
     [ObservableProperty]
     private Guid? _editingTodoId;
 
@@ -73,6 +76,7 @@ public partial class TodoListViewModel : ObservableObject
         IncompleteTodos.Clear();
         CompletedTodos.Clear();
 
+        // 视图层直接维护两个分组集合，避免每次绑定刷新时重复做筛选。
         foreach (var todo in todos)
         {
             if (todo.IsCompleted)
@@ -131,14 +135,14 @@ public partial class TodoListViewModel : ObservableObject
 
         if (updatedTodo.IsCompleted)
         {
-            // 从未完成列表移到已完成列表
+            // 完成项通常需要靠前显示，便于用户确认刚完成的动作。
             IncompleteTodos.Remove(todoItem);
             CompletedTodos.Insert(0, updatedTodo);
             SetStatus("已完成待办事项");
         }
         else
         {
-            // 从已完成列表移回未完成列表
+            // 恢复为未完成时同样插回顶部，避免用户重新查找。
             CompletedTodos.Remove(todoItem);
             IncompleteTodos.Insert(0, updatedTodo);
             SetStatus("已标记为未完成");
@@ -250,7 +254,7 @@ public partial class TodoListViewModel : ObservableObject
     [RelayCommand]
     public void OnInputLostFocus()
     {
-        // 失焦时直接收起输入框并清空内容
+        // 输入区是轻量级临时入口，失焦后直接收起，避免残留半成品内容。
         IsInputVisible = false;
         NewTodoContent = string.Empty;
     }
@@ -282,7 +286,7 @@ public partial class TodoListViewModel : ObservableObject
             return;
         }
 
-        // 查找正在编辑的项
+        // 编辑对象可能位于任一分组，因此需要跨集合查找当前项。
         var todoItem = IncompleteTodos.FirstOrDefault(t => t.Id == EditingTodoId)
                       ?? CompletedTodos.FirstOrDefault(t => t.Id == EditingTodoId);
 
@@ -308,13 +312,13 @@ public partial class TodoListViewModel : ObservableObject
 
     partial void OnIsInputVisibleChanged(bool value)
     {
-        // 初始化期间不触发保存事件
+        // 初始化阶段只是还原设置，不应反向触发一次新的保存流程。
         if (_isInitializing)
         {
             return;
         }
 
-        // 触发事件，通知 MainViewModel 保存设置
+        // 由 MainViewModel 统一负责设置持久化，避免子 ViewModel 直接依赖设置服务。
         InputVisibilityChanged?.Invoke(this, value);
     }
 

--- a/src/DesktopMemo.Core/Models/Memo.cs
+++ b/src/DesktopMemo.Core/Models/Memo.cs
@@ -5,7 +5,8 @@ using System.Linq;
 namespace DesktopMemo.Core.Models;
 
 /// <summary>
-/// 表示一条完整的备忘录数据。
+/// 表示一条完整的备忘录聚合数据。
+/// 该模型同时承担 UI 展示、持久化和未来同步场景中的主实体角色。
 /// </summary>
 public sealed record Memo(
     Guid Id,
@@ -21,7 +22,8 @@ public sealed record Memo(
     DateTimeOffset? DeletedAt = null)
 {
     /// <summary>
-    /// 获取用于显示的标题。如果内容不为空，使用第一行作为标题；否则使用原标题。
+    /// 获取用于显示的标题。
+    /// 当正文首行可读时，优先把首行当作临时标题展示，以降低用户必须维护显式标题的成本。
     /// </summary>
     public string DisplayTitle => GetDisplayTitle();
 
@@ -42,6 +44,9 @@ public sealed record Memo(
 
         return firstLine.Length > 50 ? firstLine.Substring(0, 50) + "..." : firstLine;
     }
+    /// <summary>
+    /// 创建一条全新的本地备忘录，并基于正文生成预览内容。
+    /// </summary>
     public static Memo CreateNew(string title, string content)
     {
         var now = DateTimeOffset.Now;
@@ -58,6 +63,9 @@ public sealed record Memo(
             false);
     }
 
+    /// <summary>
+    /// 更新正文，同时刷新预览、更新时间和同步状态。
+    /// </summary>
     public Memo WithContent(string content, DateTimeOffset timestamp) => this with
     {
         Content = content,
@@ -67,6 +75,9 @@ public sealed record Memo(
         SyncStatus = SyncStatus.PendingSync
     };
 
+    /// <summary>
+    /// 更新标题、标签和置顶状态等元数据。
+    /// </summary>
     public Memo WithMetadata(string title, IReadOnlyList<string> tags, bool isPinned, DateTimeOffset timestamp) => this with
     {
         Title = title,
@@ -94,6 +105,10 @@ public sealed record Memo(
         SyncStatus = SyncStatus.Conflict
     };
 
+    /// <summary>
+    /// 生成用于列表页的短预览。
+    /// 优先保留首行可读性，其次在固定长度内截断，避免列表项被大段正文撑开。
+    /// </summary>
     private static string BuildPreview(string content)
     {
         if (string.IsNullOrWhiteSpace(content))

--- a/src/DesktopMemo.Infrastructure/Memos/MemoMarkdownFrontMatterParser.cs
+++ b/src/DesktopMemo.Infrastructure/Memos/MemoMarkdownFrontMatterParser.cs
@@ -13,8 +13,17 @@ internal sealed record MemoFrontMatter(
     IReadOnlyList<string> Tags,
     bool IsPinned);
 
+/// <summary>
+/// 解析 Markdown 文件中的 YAML Front Matter。
+/// 当前实现采用轻量级逐行解析，而不是完整 YAML 解析器，
+/// 以便稳定处理项目内固定格式的数据并减少依赖。
+/// </summary>
 internal static class MemoMarkdownFrontMatterParser
 {
+    /// <summary>
+    /// 从 front matter 文本中提取备忘录元数据。
+    /// 未识别或解析失败的字段会被安全忽略，调用方再决定如何回退。
+    /// </summary>
     public static MemoFrontMatter Parse(string yaml)
     {
         Guid? id = null;
@@ -28,6 +37,7 @@ internal static class MemoMarkdownFrontMatterParser
         string? line;
         while ((line = reader.ReadLine()) is not null)
         {
+            // 这里按字段前缀做解析，前提是写入端输出的是稳定的单行 key:value 结构。
             if (line.StartsWith("id:", StringComparison.Ordinal))
             {
                 if (Guid.TryParse(line[3..].Trim(), out var parsedId))
@@ -70,6 +80,7 @@ internal static class MemoMarkdownFrontMatterParser
             }
             else if (line.TrimStart().StartsWith("-", StringComparison.Ordinal))
             {
+                // tags 使用 YAML 列表表示，当前只解析一层短横线列表项。
                 var dashIndex = line.IndexOf('-');
                 if (dashIndex >= 0)
                 {

--- a/src/DesktopMemo.Infrastructure/Repositories/SqliteIndexedMemoRepository.cs
+++ b/src/DesktopMemo.Infrastructure/Repositories/SqliteIndexedMemoRepository.cs
@@ -19,6 +19,7 @@ namespace DesktopMemo.Infrastructure.Repositories;
 /// 混合存储架构的备忘录 Repository：
 /// - SQLite 存储元数据索引（快速查询）
 /// - Markdown 文件存储完整内容（可移植性）
+/// 这样既保留文本文件的可迁移性，又能获得列表查询和筛选时的数据库性能。
 /// </summary>
 public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
 {
@@ -39,6 +40,10 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
         InitializeDatabase();
     }
 
+    /// <summary>
+    /// 初始化 SQLite 元数据表与索引。
+    /// 该方法只负责元数据结构，正文内容仍由 Markdown 文件承载。
+    /// </summary>
     private void InitializeDatabase()
     {
         using var connection = new SqliteConnection(_connectionString);
@@ -125,10 +130,10 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                // 从 Markdown 文件读取内容
+                // 列表查询先走数据库拿索引，再按文件路径加载正文。
                 var content = await LoadContentFromFileAsync(dto.FilePath, cancellationToken).ConfigureAwait(false);
 
-                // 回退：若数据库记录的 file_path 无法读取，则尝试使用标准路径并自愈更新数据库
+                // 若数据库中的 file_path 已过期，则按标准命名规则回退并顺手修复元数据。
                 if (content == null)
                 {
                     var id = Guid.Parse(dto.Id);
@@ -224,7 +229,7 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
             var filePath = GetMemoPath(memo.Id);
             var tempFilePath = filePath + ".tmp";
 
-            // 1. 先写入临时文件
+            // 先写临时 Markdown 文件，再写数据库，尽量避免出现“数据库有记录但正文文件不完整”的状态。
             await SaveContentToFileAsync(tempFilePath, memo, cancellationToken).ConfigureAwait(false);
 
             // 2. 保存元数据到 SQLite
@@ -235,7 +240,7 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
 
             try
             {
-                // 插入备忘录元数据
+                // 事务内写入索引和标签，确保元数据始终自洽。
                 const string insertMemoSql = @"
                     INSERT INTO memos (
                         id, title, preview, is_pinned, created_at, updated_at,
@@ -258,7 +263,7 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
                     SyncStatus = (int)memo.SyncStatus
                 }, transaction).ConfigureAwait(false);
 
-                // 插入标签
+                // 标签去重后逐条写入关联表。
                 if (memo.Tags.Any())
                 {
                     const string insertTagSql = "INSERT INTO memo_tags (memo_id, tag) VALUES (@MemoId, @Tag)";
@@ -274,14 +279,14 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
 
                 await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
 
-                // 3. 事务成功后，将临时文件重命名为正式文件
+                // 数据库提交成功后再原子替换正式文件，减少部分写入留下坏文件的风险。
                 File.Move(tempFilePath, filePath, overwrite: true);
             }
             catch
             {
                 await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
 
-                // 事务失败，删除临时文件
+                // 回滚后清理临时文件，避免后续恢复时误判为有效内容。
                 if (File.Exists(tempFilePath))
                 {
                     File.Delete(tempFilePath);
@@ -304,7 +309,7 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
             var filePath = GetMemoPath(memo.Id);
             var tempFilePath = filePath + ".tmp";
 
-            // 1. 先写入临时文件
+            // 更新沿用“临时文件 + 数据库事务 + 原子替换”的写入策略。
             await SaveContentToFileAsync(tempFilePath, memo, cancellationToken).ConfigureAwait(false);
 
             // 2. 更新 SQLite 元数据
@@ -315,7 +320,7 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
 
             try
             {
-                // 更新备忘录元数据
+                // 正文写入文件，数据库只更新列表展示和检索需要的字段。
                 const string updateMemoSql = @"
                     UPDATE memos SET
                         title = @Title,
@@ -342,11 +347,11 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
                     throw new InvalidOperationException($"Memo {memo.Id} 不存在或已删除");
                 }
 
-                // 删除旧标签
+                // 标签模型当前采用全量替换，逻辑简单且对数据量足够友好。
                 const string deleteTagsSql = "DELETE FROM memo_tags WHERE memo_id = @MemoId";
                 await connection.ExecuteAsync(deleteTagsSql, new { MemoId = memo.Id.ToString() }, transaction).ConfigureAwait(false);
 
-                // 插入新标签
+                // 插回新的标签集合。
                 if (memo.Tags.Any())
                 {
                     const string insertTagSql = "INSERT INTO memo_tags (memo_id, tag) VALUES (@MemoId, @Tag)";
@@ -362,14 +367,14 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
 
                 await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
 
-                // 3. 事务成功后，将临时文件重命名为正式文件
+                // 元数据落库成功后，再让正文文件生效。
                 File.Move(tempFilePath, filePath, overwrite: true);
             }
             catch
             {
                 await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
 
-                // 事务失败，删除临时文件
+                // 出错时清理临时文件，避免遗留脏状态。
                 if (File.Exists(tempFilePath))
                 {
                     File.Delete(tempFilePath);
@@ -392,7 +397,7 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
             using var connection = new SqliteConnection(_connectionString);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-            // 软删除（标记为已删除，支持云同步和数据恢复）
+            // 软删除保留文件和标签，便于后续恢复或同步系统识别删除事件。
             const string updateMemoSql = @"
                 UPDATE memos
                 SET deleted_at = @DeletedAt,
@@ -418,6 +423,9 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
 
     private string GetMemoPath(Guid id) => Path.Combine(_contentDirectory, $"{id:N}.md");
 
+    /// <summary>
+    /// 读取 Markdown 正文，并跳过文件开头的 YAML Front Matter。
+    /// </summary>
     private async Task<string?> LoadContentFromFileAsync(string filePath, CancellationToken cancellationToken)
     {
         if (!File.Exists(filePath))
@@ -430,7 +438,7 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
             await using var stream = File.OpenRead(filePath);
             using var reader = new StreamReader(stream, Encoding.UTF8);
 
-            // 跳过 YAML Front Matter
+            // Markdown 文件头部保存元数据，这里只返回正文给领域模型。
             var firstLine = await reader.ReadLineAsync().ConfigureAwait(false);
             if (firstLine?.Equals("---", StringComparison.Ordinal) == true)
             {
@@ -444,7 +452,6 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
                 }
             }
 
-            // 读取内容
             return await reader.ReadToEndAsync().ConfigureAwait(false);
         }
         catch (UnauthorizedAccessException ex)
@@ -464,6 +471,9 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
         }
     }
 
+    /// <summary>
+    /// 将备忘录写回 Markdown 文件，front matter 与正文保持同源输出。
+    /// </summary>
     private async Task SaveContentToFileAsync(string filePath, Memo memo, CancellationToken cancellationToken)
     {
         var builder = new StringBuilder();
@@ -511,7 +521,7 @@ public sealed class SqliteIndexedMemoRepository : IMemoRepository, IDisposable
                 ? Array.Empty<string>()
                 : Tags.Split(',', StringSplitOptions.RemoveEmptyEntries);
 
-            // 兼容空字符串与非ISO格式的时间
+            // 兼容旧数据、空字符串和非标准时间格式，避免单条脏数据拖垮整个列表读取。
             static DateTimeOffset ParseRequired(string value)
             {
                 if (DateTimeOffset.TryParse(value, System.Globalization.CultureInfo.InvariantCulture,

--- a/src/DesktopMemo.Infrastructure/Repositories/SqliteTodoRepository.cs
+++ b/src/DesktopMemo.Infrastructure/Repositories/SqliteTodoRepository.cs
@@ -13,7 +13,7 @@ namespace DesktopMemo.Infrastructure.Repositories;
 
 /// <summary>
 /// 基于 SQLite 的待办事项存储实现。
-/// 为未来云同步功能预留扩展。
+/// 采用软删除与同步状态字段，为未来云同步功能预留扩展空间。
 /// </summary>
 public sealed class SqliteTodoRepository : ITodoRepository, IDisposable
 {
@@ -64,6 +64,9 @@ public sealed class SqliteTodoRepository : ITodoRepository, IDisposable
         command.ExecuteNonQuery();
     }
 
+    /// <summary>
+    /// 读取全部未删除待办项，并按用户期望的展示顺序返回。
+    /// </summary>
     public async Task<IReadOnlyList<TodoItem>> GetAllAsync(CancellationToken cancellationToken = default)
     {
         await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -86,6 +89,9 @@ public sealed class SqliteTodoRepository : ITodoRepository, IDisposable
         }
     }
 
+    /// <summary>
+    /// 根据主键读取单条待办项；已软删除的数据不会返回。
+    /// </summary>
     public async Task<TodoItem?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
         await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -105,6 +111,9 @@ public sealed class SqliteTodoRepository : ITodoRepository, IDisposable
         }
     }
 
+    /// <summary>
+    /// 新增待办项。
+    /// </summary>
     public async Task AddAsync(TodoItem todoItem, CancellationToken cancellationToken = default)
     {
         await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -132,6 +141,9 @@ public sealed class SqliteTodoRepository : ITodoRepository, IDisposable
         }
     }
 
+    /// <summary>
+    /// 更新待办项的正文、完成状态、排序和同步状态。
+    /// </summary>
     public async Task UpdateAsync(TodoItem todoItem, CancellationToken cancellationToken = default)
     {
         await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -164,6 +176,9 @@ public sealed class SqliteTodoRepository : ITodoRepository, IDisposable
         }
     }
 
+    /// <summary>
+    /// 软删除待办项，保留记录以便未来同步系统感知删除事件。
+    /// </summary>
     public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
     {
         await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -258,6 +273,7 @@ public sealed class SqliteTodoRepository : ITodoRepository, IDisposable
 
         public TodoItem ToModel()
         {
+            // 数据库层使用字符串保存时间，转换时对旧格式或异常值做容错。
             static DateTimeOffset ParseRequired(string value)
             {
                 if (DateTimeOffset.TryParse(value, System.Globalization.CultureInfo.InvariantCulture,
@@ -296,6 +312,7 @@ public sealed class SqliteTodoRepository : ITodoRepository, IDisposable
 
         public static TodoItemDto FromModel(TodoItem item)
         {
+            // 统一在 DTO 层处理布尔和时间的数据库表示，避免仓储方法重复拼装。
             return new TodoItemDto
             {
                 Id = item.Id.ToString(),

--- a/src/DesktopMemo.Infrastructure/Services/JsonSettingsService.cs
+++ b/src/DesktopMemo.Infrastructure/Services/JsonSettingsService.cs
@@ -12,7 +12,8 @@ using System.Diagnostics;
 namespace DesktopMemo.Infrastructure.Services;
 
 /// <summary>
-/// 使用 JSON 文件存储窗口设置。
+/// 使用 JSON 文件存储窗口与全局设置。
+/// 读取时尽量容错，保存时尽量规范化，避免设置文件损坏影响主流程。
 /// </summary>
 public sealed class JsonSettingsService : ISettingsService
 {
@@ -30,6 +31,9 @@ public sealed class JsonSettingsService : ISettingsService
         _settingsFile = Path.Combine(dataDirectory, "settings.json");
     }
 
+    /// <summary>
+    /// 从 `settings.json` 读取设置；若文件缺失或损坏，则安全回退到默认值。
+    /// </summary>
     public async Task<WindowSettings> LoadAsync(CancellationToken cancellationToken = default)
     {
         if (!File.Exists(_settingsFile))
@@ -54,7 +58,7 @@ public sealed class JsonSettingsService : ISettingsService
                 return WindowSettings.Default;
             }
 
-            // 验证和修复透明度值
+            // 设置文件可能来自旧版本或手工编辑，这里做一次容错规范化。
             var normalizedTransparency = TransparencyHelper.NormalizeTransparency(settings.Transparency);
             if (Math.Abs(settings.Transparency - normalizedTransparency) > 0.001)
             {
@@ -68,7 +72,7 @@ public sealed class JsonSettingsService : ISettingsService
         catch (JsonException ex)
         {
             Debug.WriteLine($"设置文件JSON格式错误: {ex.Message}，使用默认设置");
-            // 备份损坏的设置文件
+            // JSON 损坏时保留现场，方便用户回滚或开发者排查。
             try
             {
                 File.Copy(_settingsFile, _settingsFile + ".backup", true);
@@ -84,11 +88,14 @@ public sealed class JsonSettingsService : ISettingsService
         }
     }
 
+    /// <summary>
+    /// 把设置序列化到磁盘。
+    /// </summary>
     public async Task SaveAsync(WindowSettings settings, CancellationToken cancellationToken = default)
     {
         try
         {
-            // 在保存前验证设置
+            // 保存前统一做一次规范化，避免无效透明度持续在文件中传播。
             var normalizedTransparency = TransparencyHelper.NormalizeTransparency(settings.Transparency);
             if (Math.Abs(settings.Transparency - normalizedTransparency) > 0.001)
             {
@@ -106,7 +113,7 @@ public sealed class JsonSettingsService : ISettingsService
         catch (Exception ex)
         {
             Debug.WriteLine($"保存设置文件失败: {ex.Message}");
-            throw; // 重新抛出异常，让调用者知道保存失败
+            throw; // 保持失败可见，让上层决定是否提示用户或重试。
         }
     }
 }

--- a/src/DesktopMemo.Infrastructure/Services/MemoFrontMatterTimestampSyncService.cs
+++ b/src/DesktopMemo.Infrastructure/Services/MemoFrontMatterTimestampSyncService.cs
@@ -10,6 +10,10 @@ using Microsoft.Data.Sqlite;
 
 namespace DesktopMemo.Infrastructure.Services;
 
+/// <summary>
+/// 启动阶段用于校准 SQLite 时间索引与 Markdown front matter 时间字段的一致性。
+/// 该同步只回写数据库，不改动 Markdown 文件本身。
+/// </summary>
 public sealed class MemoFrontMatterTimestampSyncService
 {
     private readonly string _dbPath;
@@ -25,6 +29,9 @@ public sealed class MemoFrontMatterTimestampSyncService
         _logService = logService;
     }
 
+    /// <summary>
+    /// 扫描全部未删除备忘录，并把 Markdown 中的 createdAt / updatedAt 同步回数据库。
+    /// </summary>
     public async Task<MemoFrontMatterTimestampSyncResult> SyncAsync(CancellationToken cancellationToken = default)
     {
         if (!File.Exists(_dbPath))
@@ -63,6 +70,7 @@ public sealed class MemoFrontMatterTimestampSyncService
 
             try
             {
+                // 旧版本可能残留错误 file_path，这里会尝试标准路径回退并修复数据库记录。
                 var filePath = await ResolveFilePathAsync(connection, row, memoId).ConfigureAwait(false);
                 if (filePath is null)
                 {
@@ -74,6 +82,7 @@ public sealed class MemoFrontMatterTimestampSyncService
                 var yaml = await MemoMarkdownDocumentReader.ReadFrontMatterAsync(filePath, cancellationToken).ConfigureAwait(false);
                 var frontMatter = MemoMarkdownFrontMatterParser.Parse(yaml);
 
+                // front matter 中若显式声明了不同的 ID，说明文件与索引可能错配，不能盲目回写。
                 if (frontMatter.Id is Guid frontMatterId && frontMatterId != memoId)
                 {
                     skippedCount++;
@@ -96,6 +105,7 @@ public sealed class MemoFrontMatterTimestampSyncService
 
                 if (dbCreatedAt == markdownCreatedAt && dbUpdatedAt == markdownUpdatedAt)
                 {
+                    // 时间一致时不做额外写入，减少数据库压力。
                     continue;
                 }
 
@@ -157,6 +167,7 @@ public sealed class MemoFrontMatterTimestampSyncService
 
         if (!string.Equals(row.FilePath, fallbackPath, StringComparison.OrdinalIgnoreCase))
         {
+            // 这里顺带自愈旧路径，避免后续每次启动都重复走回退逻辑。
             const string updatePathSql = @"
                 UPDATE memos
                 SET file_path = @FilePath
@@ -191,6 +202,9 @@ public sealed class MemoFrontMatterTimestampSyncService
     }
 }
 
+/// <summary>
+/// front matter 时间同步结果摘要，用于日志与测试断言。
+/// </summary>
 public sealed record MemoFrontMatterTimestampSyncResult(
     int ScannedCount,
     int UpdatedCount,

--- a/src/DesktopMemo.Infrastructure/Services/MemoMetadataMigrationService.cs
+++ b/src/DesktopMemo.Infrastructure/Services/MemoMetadataMigrationService.cs
@@ -36,7 +36,7 @@ public sealed class MemoMetadataMigrationService
         var memosDb = Path.Combine(dataDirectory, "memos.db");
         var backupFile = Path.Combine(contentDir, $"index_backup_{DateTime.Now:yyyyMMddHHmmss}.json");
 
-        // 如果 SQLite 数据库已存在，进一步检查是否为空库（没有任何 memo 记录）
+        // 若索引库已存在，需要进一步判断它是有效数据还是仅仅一个空壳文件。
         if (File.Exists(memosDb))
         {
             _logger?.LogInformation("✓ 检测到 SQLite 数据库文件存在: {DbPath}", memosDb);
@@ -45,7 +45,7 @@ public sealed class MemoMetadataMigrationService
                 using var connection = new SqliteConnection($"Data Source={memosDb}");
                 connection.Open();
 
-                // 确保表存在
+                // 兼容“数据库文件已创建但表还没建好”的中间状态。
                 var initCmd = connection.CreateCommand();
                 initCmd.CommandText = @"CREATE TABLE IF NOT EXISTS memos (
                     id TEXT PRIMARY KEY,
@@ -75,7 +75,7 @@ public sealed class MemoMetadataMigrationService
                 {
                     _logger?.LogInformation("⚠ 检测到 SQLite 索引存在但为空，将尝试从 index.json 进行迁移");
                     System.Diagnostics.Debug.WriteLine("[迁移检查] SQLite为空，将执行迁移");
-                    // 继续执行迁移逻辑（不 return）
+                    // 空索引允许继续从 index.json 重建。
                 }
             }
             catch (Exception ex)
@@ -84,7 +84,7 @@ public sealed class MemoMetadataMigrationService
             }
         }
 
-        // 如果 content 目录不存在，说明没有数据
+        // 没有 content 目录时，也要创建空索引库，保证新版本后续流程正常。
         if (!Directory.Exists(contentDir))
         {
             _logger?.LogInformation("content 目录不存在，无需迁移");
@@ -100,7 +100,7 @@ public sealed class MemoMetadataMigrationService
             _logger?.LogInformation("⚡ 开始迁移备忘录元数据到 SQLite 索引...");
             System.Diagnostics.Debug.WriteLine("[迁移执行] 开始从 index.json 迁移到 SQLite");
 
-            // 1. 使用旧的 Repository 读取所有备忘录
+            // 1. 先复用旧仓储读取 index.json 和正文文件，避免重复兼容逻辑。
             var oldRepository = new FileMemoRepository(dataDirectory);
             var memos = await oldRepository.GetAllAsync(cancellationToken).ConfigureAwait(false);
 
@@ -111,10 +111,10 @@ public sealed class MemoMetadataMigrationService
             {
                 _logger?.LogInformation("没有备忘录需要迁移");
                 
-                // 创建空的 SQLite 数据库
+                // 即使没有数据也创建空库，表示迁移流程已完成。
                 using var emptyRepo = new SqliteIndexedMemoRepository(dataDirectory);
                 
-                // 备份 index.json（如果存在）
+                // 把旧索引文件改名备份，防止下次启动继续触发迁移。
                 if (File.Exists(indexFile))
                 {
                     File.Move(indexFile, backupFile);
@@ -124,7 +124,7 @@ public sealed class MemoMetadataMigrationService
                 return new MigrationResult(true, 0, "没有备忘录需要迁移");
             }
 
-            // 2. 创建 SQLite Repository 并写入数据
+            // 2. 用新仓储重建索引；正文仍留在原 Markdown 文件中。
             System.Diagnostics.Debug.WriteLine($"[迁移执行] 开始写入 {memos.Count} 条备忘录到 SQLite（这会更新文件修改时间）");
             using (var sqliteRepository = new SqliteIndexedMemoRepository(dataDirectory))
             {
@@ -137,7 +137,7 @@ public sealed class MemoMetadataMigrationService
                 System.Diagnostics.Debug.WriteLine($"[迁移执行] ✓ 已写入 {written} 条备忘录");
             }
 
-            // 3. 备份原 index.json 文件
+            // 3. 迁移成功后再备份原 index.json，降低中途失败时的数据风险。
             if (File.Exists(indexFile))
             {
                 File.Move(indexFile, backupFile);

--- a/src/DesktopMemo.Infrastructure/Services/MemoMigrationService.cs
+++ b/src/DesktopMemo.Infrastructure/Services/MemoMigrationService.cs
@@ -9,6 +9,10 @@ using Markdig;
 
 namespace DesktopMemo.Infrastructure.Services;
 
+/// <summary>
+/// 旧版备忘录导入服务。
+/// 用于把早期版本保存在应用目录下的 Markdown 数据导入到新模型中。
+/// </summary>
 public sealed class MemoMigrationService
 {
     private readonly string _dataDirectory;
@@ -23,11 +27,14 @@ public sealed class MemoMigrationService
 
     public string ExportDirectory { get; }
 
+    /// <summary>
+    /// 扫描旧版 `Data/content` 目录中的 Markdown 文件并转换为 Memo。
+    /// </summary>
     public async Task<IReadOnlyList<Memo>> LoadFromLegacyAsync()
     {
         var results = new List<Memo>();
         
-        // 在应用程序目录下查找旧应用数据目录 Data/content
+        // 旧版本把数据放在程序目录下，迁移时按原布局直接扫描。
         var legacyContentDir = Path.Combine(_appDirectory, "Data", "content");
 
         if (Directory.Exists(legacyContentDir))
@@ -43,11 +50,14 @@ public sealed class MemoMigrationService
             }
         }
 
-        // TODO: 支持旧 JSON 格式迁移，可参考 .old 逻辑
+        // 目前只支持 Markdown 目录导入，更多历史格式留待后续补齐。
 
         return results;
     }
 
+    /// <summary>
+    /// 把旧 Markdown 文件转换为当前 Memo 模型。
+    /// </summary>
     private static Memo? ParseMarkdown(string fileName, string markdown, DateTime created, DateTime updated)
     {
         if (string.IsNullOrWhiteSpace(markdown))
@@ -55,6 +65,7 @@ public sealed class MemoMigrationService
             return null;
         }
 
+        // 当前只需要提取标题与时间，解析 Markdown 主要是为后续扩展保留入口。
         var pipeline = new MarkdownPipelineBuilder().Build();
         var document = Markdown.Parse(markdown, pipeline);
 
@@ -80,6 +91,9 @@ public sealed class MemoMigrationService
             false);
     }
 
+    /// <summary>
+    /// 为迁移进来的旧备忘录生成列表预览文本。
+    /// </summary>
     private static string BuildPreview(string content)
     {
         if (string.IsNullOrWhiteSpace(content))

--- a/src/DesktopMemo.Infrastructure/Services/TodoMigrationService.cs
+++ b/src/DesktopMemo.Infrastructure/Services/TodoMigrationService.cs
@@ -34,7 +34,7 @@ public sealed class TodoMigrationService
         var sqliteDb = Path.Combine(dataDirectory, "todos.db");
         var backupFile = Path.Combine(dataDirectory, $"todos_backup_{DateTime.Now:yyyyMMddHHmmss}.json");
 
-        // 如果 SQLite 数据库已存在且包含数据，则认为已经迁移过
+        // 若目标库已有数据，则认为迁移已完成，避免重复导入造成重复记录。
         if (File.Exists(sqliteDb))
         {
             try
@@ -42,7 +42,7 @@ public sealed class TodoMigrationService
                 using var connection = new SqliteConnection($"Data Source={sqliteDb}");
                 connection.Open();
 
-                // 确保表存在（可能是空数据库）
+                // 有些用户可能已经生成了空数据库，因此先补齐表结构再判断是否需要迁移。
                 using var initCmd = connection.CreateCommand();
                 initCmd.CommandText = @"
                     CREATE TABLE IF NOT EXISTS todos (
@@ -77,7 +77,7 @@ public sealed class TodoMigrationService
                 else
                 {
                     _logger?.LogInformation("⚠ 检测到 SQLite 数据库存在但为空，将尝试从 JSON 进行迁移");
-                    // 继续执行迁移逻辑（不 return）
+                    // 空库允许继续从旧 JSON 导入。
                 }
             }
             catch (Exception ex)
@@ -87,7 +87,7 @@ public sealed class TodoMigrationService
             }
         }
 
-        // 如果 JSON 文件不存在，则没有数据需要迁移
+        // 源文件不存在时说明没有历史数据，属于正常情况。
         if (!File.Exists(jsonFile))
         {
             _logger?.LogInformation("未找到 JSON 文件，无需迁移");
@@ -98,7 +98,7 @@ public sealed class TodoMigrationService
         {
             _logger?.LogInformation("开始从 JSON 迁移到 SQLite...");
 
-            // 1. 读取 JSON 数据
+            // 1. 先用旧仓储读取 JSON，复用原有解析逻辑避免重复实现。
             var jsonRepository = new JsonTodoRepository(dataDirectory);
             var todos = await jsonRepository.GetAllAsync(cancellationToken).ConfigureAwait(false);
 
@@ -106,7 +106,7 @@ public sealed class TodoMigrationService
             {
                 _logger?.LogInformation("JSON 文件为空，无需迁移");
                 
-                // 即使数据为空，也创建 SQLite 数据库并备份 JSON 文件
+                // 即使 JSON 为空，也生成新库并备份源文件，表示迁移流程已跑完。
                 var emptyRepo = new SqliteTodoRepository(dataDirectory);
                 emptyRepo.Dispose();
                 
@@ -119,7 +119,7 @@ public sealed class TodoMigrationService
                 return new MigrationResult(true, 0, "JSON 文件为空");
             }
 
-            // 2. 创建 SQLite 数据库并写入数据
+            // 2. 再批量写入 SQLite，完成新格式落地。
             using (var sqliteRepository = new SqliteTodoRepository(dataDirectory))
             {
                 foreach (var todo in todos)
@@ -128,7 +128,7 @@ public sealed class TodoMigrationService
                 }
             }
 
-            // 3. 备份原 JSON 文件
+            // 3. 最后备份旧文件，避免后续再次被识别成待迁移数据源。
             File.Move(jsonFile, backupFile);
 
             _logger?.LogInformation("✅ 成功迁移 {Count} 条待办事项", todos.Count);

--- a/src/DesktopMemo.Infrastructure/Services/TrayService.cs
+++ b/src/DesktopMemo.Infrastructure/Services/TrayService.cs
@@ -8,6 +8,10 @@ using Forms = System.Windows.Forms;
 
 namespace DesktopMemo.Infrastructure.Services;
 
+/// <summary>
+/// 系统托盘服务。
+/// 负责创建 NotifyIcon、构建右键菜单，并把菜单动作转发为上层事件。
+/// </summary>
 public sealed class TrayService : ITrayService
 {
     private Forms.NotifyIcon? _notifyIcon;
@@ -65,6 +69,9 @@ public sealed class TrayService : ITrayService
 
     public bool IsClickThroughEnabled { get; private set; }
 
+    /// <summary>
+    /// 初始化托盘图标与上下文菜单。
+    /// </summary>
     public void Initialize()
     {
         if (_notifyIcon != null)
@@ -77,7 +84,7 @@ public sealed class TrayService : ITrayService
             _notifyIcon = new Forms.NotifyIcon
             {
                 Text = "DesktopMemo 便签 - 桌面便签工具",
-                Visible = false // 先设为false，避免在未完全初始化时显示
+                Visible = false // 初始化未完成前不显示，避免半成品菜单暴露给用户。
             };
 
             SetTrayIcon();
@@ -87,7 +94,7 @@ public sealed class TrayService : ITrayService
         }
         catch (Exception)
         {
-            // 如果托盘图标初始化失败，创建一个最简单的版本
+            // 如果完整初始化失败，退回到最小可用的系统默认图标版本。
             try
             {
                 _notifyIcon = new Forms.NotifyIcon
@@ -100,7 +107,7 @@ public sealed class TrayService : ITrayService
             }
             catch
             {
-                // 如果连简单版本都失败，则忽略托盘功能
+                // 如果连最小版本都失败，则整个托盘功能降级为不可用。
                 _notifyIcon = null;
             }
         }
@@ -149,6 +156,9 @@ public sealed class TrayService : ITrayService
         }
     }
 
+    /// <summary>
+    /// 同步托盘菜单中置顶模式的勾选状态。
+    /// </summary>
     public void UpdateTopmostState(TopmostMode mode)
     {
         try
@@ -163,6 +173,9 @@ public sealed class TrayService : ITrayService
         }
     }
 
+    /// <summary>
+    /// 把托盘菜单中的置顶模式选择转发给外层。
+    /// </summary>
     private void OnTopmostModeChanged(TopmostMode mode)
     {
         try
@@ -175,6 +188,9 @@ public sealed class TrayService : ITrayService
         }
     }
 
+    /// <summary>
+    /// 同步穿透模式的勾选状态。
+    /// </summary>
     public void UpdateClickThroughState(bool enabled)
     {
         try
@@ -220,6 +236,9 @@ public sealed class TrayService : ITrayService
         Dispose();
     }
 
+    /// <summary>
+    /// 为托盘选择图标，优先复用缓存，避免重复从可执行文件提取。
+    /// </summary>
     private void SetTrayIcon()
     {
         if (_notifyIcon == null)
@@ -231,6 +250,7 @@ public sealed class TrayService : ITrayService
         {
             if (_cachedTrayIcon != null)
             {
+                // 托盘图标通常在整个进程生命周期内固定，缓存可减少 GDI 资源重复分配。
                 _notifyIcon.Icon = _cachedTrayIcon;
                 return;
             }
@@ -268,6 +288,9 @@ public sealed class TrayService : ITrayService
         }
     }
 
+    /// <summary>
+    /// 构建深色风格托盘菜单，并为每个菜单项绑定对应事件。
+    /// </summary>
     private void BuildContextMenu()
     {
         if (_notifyIcon == null)
@@ -286,6 +309,7 @@ public sealed class TrayService : ITrayService
             ForeColor = Color.FromArgb(241, 241, 241)
         };
 
+        // WinForms 托盘菜单默认双缓冲能力有限，这里通过反射减少展开时闪烁。
         typeof(Forms.ToolStripDropDownMenu).InvokeMember("DoubleBuffered",
             System.Reflection.BindingFlags.SetProperty | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
             null, _contextMenu, new object[] { true });
@@ -311,7 +335,7 @@ public sealed class TrayService : ITrayService
         _topmostDesktopItem = new Forms.ToolStripMenuItem("桌面置顶") { Font = _regularFont };
         _topmostAlwaysItem = new Forms.ToolStripMenuItem("总是置顶") { Font = _regularFont };
         
-        // 添加事件处理，避免在点击时调用UpdateTopmostState（那个是用来更新UI状态的）
+        // 这里触发的是“用户操作事件”，而不是单纯刷新 UI 勾选状态。
         _topmostNormalItem.Click += (s, e) => OnTopmostModeChanged(TopmostMode.Normal);
         _topmostDesktopItem.Click += (s, e) => OnTopmostModeChanged(TopmostMode.Desktop);
         _topmostAlwaysItem.Click += (s, e) => OnTopmostModeChanged(TopmostMode.Always);
@@ -414,6 +438,9 @@ public sealed class TrayService : ITrayService
         });
     }
 
+    /// <summary>
+    /// 根据当前语言刷新全部托盘菜单文本。
+    /// </summary>
     public void UpdateMenuTexts(Func<string, string> getLocalizedString)
     {
         try
@@ -453,6 +480,9 @@ public sealed class TrayService : ITrayService
         }
     }
 
+    /// <summary>
+    /// 自定义深色托盘菜单渲染器，使托盘菜单与应用主题风格更接近。
+    /// </summary>
     private sealed class DarkTrayMenuRenderer : Forms.ToolStripProfessionalRenderer
     {
         public DarkTrayMenuRenderer() : base(new DarkColorTable())
@@ -531,6 +561,9 @@ public sealed class TrayService : ITrayService
         }
     }
 
+    /// <summary>
+    /// 深色托盘菜单配色表。
+    /// </summary>
     private sealed class DarkColorTable : Forms.ProfessionalColorTable
     {
         public override Color MenuItemSelected => Color.FromArgb(62, 62, 66);
@@ -538,6 +571,9 @@ public sealed class TrayService : ITrayService
         public override Color ToolStripDropDownBackground => Color.FromArgb(45, 45, 48);
     }
 
+    /// <summary>
+    /// 创建托盘菜单字体；若目标字体不可用，则退回系统通用无衬线字体。
+    /// </summary>
     private static Font CreateFont(string family, float size, FontStyle style)
     {
         try

--- a/src/DesktopMemo.Infrastructure/Services/WindowService.cs
+++ b/src/DesktopMemo.Infrastructure/Services/WindowService.cs
@@ -9,6 +9,10 @@ using System.Diagnostics;
 
 namespace DesktopMemo.Infrastructure.Services;
 
+/// <summary>
+/// 封装 WPF 主窗口的显示、层级、透明度和穿透行为。
+/// 该服务是 UI 层与 Win32 窗口操作之间的隔离层。
+/// </summary>
 public class WindowService : IWindowService, IDisposable
 {
     private Window? _window;
@@ -17,7 +21,7 @@ public class WindowService : IWindowService, IDisposable
     private bool _isClickThroughEnabled = false;
     private bool _isWindowActivatedHandlerAttached = false;
 
-    // Win32 API 常量
+    // Win32 API 扩展样式常量，用于控制穿透与分层渲染。
     private const int GWL_EXSTYLE = -20;
     private const int WS_EX_TRANSPARENT = 0x00000020;
     private const int WS_EX_LAYERED = 0x00080000;
@@ -54,11 +58,14 @@ public class WindowService : IWindowService, IDisposable
     private const int SW_HIDE = 0;
     private const int SW_SHOW = 5;
 
+    /// <summary>
+    /// 绑定实际窗口实例，并挂接桌面模式需要的激活事件。
+    /// </summary>
     public void Initialize(Window window)
     {
         _window = window ?? throw new ArgumentNullException(nameof(window));
-        
-        // 订阅窗口激活事件，用于桌面置顶模式
+
+        // 桌面模式下窗口被系统重新激活后，层级可能变化，需要再次校正。
         if (!_isWindowActivatedHandlerAttached)
         {
             _window.Activated += OnWindowActivated;
@@ -81,6 +88,7 @@ public class WindowService : IWindowService, IDisposable
 
         _currentTopmostMode = mode;
 
+        // 三种模式分别映射到普通层级、桌面层级和系统置顶层级。
         switch (mode)
         {
             case TopmostMode.Normal:
@@ -126,10 +134,12 @@ public class WindowService : IWindowService, IDisposable
 
         if (enabled)
         {
+            // 透明点击依赖 WS_EX_TRANSPARENT；分层窗口样式则保证透明度/命中表现稳定。
             exStyle |= WS_EX_TRANSPARENT | WS_EX_LAYERED;
         }
         else
         {
+            // 关闭穿透时保留分层样式，避免影响窗口透明度控制。
             exStyle &= ~WS_EX_TRANSPARENT;
         }
 
@@ -161,6 +171,7 @@ public class WindowService : IWindowService, IDisposable
         try
         {
             var workingArea = SystemParameters.WorkArea;
+            // 保留一小段可见区域，避免窗口被拖出屏幕后用户无法再拖回来。
             double minX = workingArea.Left - _window.Width + 50;
             double maxX = workingArea.Right - 50;
             double minY = workingArea.Top;
@@ -198,6 +209,7 @@ public class WindowService : IWindowService, IDisposable
         double windowWidth = _window.Width;
         double windowHeight = _window.Height;
 
+        // 预设位置本质上是基于工作区做九宫格定位。
         switch (position)
         {
             case "TopLeft":
@@ -245,6 +257,10 @@ public class WindowService : IWindowService, IDisposable
 
     private double _backgroundOpacity = WindowConstants.DEFAULT_TRANSPARENCY; // 存储背景透明度值
 
+    /// <summary>
+    /// 保存背景透明度数值。
+    /// 实际视觉生效由 View 层绑定或样式逻辑消费该值。
+    /// </summary>
     public void SetWindowOpacity(double opacity)
     {
         // 验证透明度值是否有效
@@ -263,6 +279,9 @@ public class WindowService : IWindowService, IDisposable
         return _backgroundOpacity; // 返回存储的背景透明度值
     }
 
+    /// <summary>
+    /// 播放窗口淡入动画，用于首次显示或从托盘恢复时的过渡。
+    /// </summary>
     public void PlayFadeInAnimation()
     {
         if (_window == null)
@@ -336,22 +355,21 @@ public class WindowService : IWindowService, IDisposable
     {
         try
         {
-            // 首先设置为非置顶
+            // 先取消系统级置顶，避免它压过正常应用窗口。
             SafeSetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE, "桌面模式-设置非置顶");
-            
-            // 找到Program Manager
+
+            // Program Manager / WorkerW 是 Windows 桌面图标层级体系中的关键窗口。
             IntPtr progmanHwnd = FindWindow("Progman", "Program Manager");
-            
+
             if (progmanHwnd != IntPtr.Zero && IsWindow(progmanHwnd))
             {
-                // 发送消息以获取WorkerW窗口
-                IntPtr result = IntPtr.Zero;
+                // 某些系统需要先唤起 WorkerW，桌面图标视图才会暴露出来。
                 SendMessage(progmanHwnd, 0x052C, IntPtr.Zero, IntPtr.Zero);
-                
-                // 查找WorkerW窗口
+
+                // 遍历 WorkerW，定位包含桌面图标视图的那一层。
                 IntPtr workerw = IntPtr.Zero;
                 IntPtr shellDllDefView = IntPtr.Zero;
-                
+
                 do
                 {
                     workerw = FindWindowEx(IntPtr.Zero, workerw, "WorkerW", null!);
@@ -365,28 +383,27 @@ public class WindowService : IWindowService, IDisposable
                     }
                 } while (workerw != IntPtr.Zero);
                 
-                // 将窗口放置在适当的位置
                 if (workerw != IntPtr.Zero)
                 {
-                    // 放置在WorkerW之上
+                    // 放到 WorkerW 之上，可实现“压在桌面上、但又不抢到应用最前”的效果。
                     SafeSetWindowPos(hwnd, workerw, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE, "桌面模式-WorkerW上方");
                 }
                 else
                 {
-                    // 如果找不到WorkerW，使用传统方法
+                    // 老系统或特殊壳层下可能找不到 WorkerW，退回到较保守的放置方式。
                     SafeSetWindowPos(hwnd, HWND_BOTTOM, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE, "桌面模式-底部");
                     SafeSetWindowPos(hwnd, progmanHwnd, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE, "桌面模式-Progman上方");
                 }
             }
             else
             {
-                // 如果找不到Program Manager，直接放置在底部
+                // 若系统窗口结构识别失败，至少保证不会错误置顶到普通应用之上。
                 SafeSetWindowPos(hwnd, HWND_BOTTOM, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE, "桌面模式-找不到Progman");
             }
         }
         catch
         {
-            // 如果任何操作失败，使用最简单的方法
+            // 任一步骤出错都退回到底层放置，优先保证稳定性。
             SafeSetWindowPos(hwnd, HWND_BOTTOM, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE, "桌面模式-异常处理");
         }
     }
@@ -399,13 +416,13 @@ public class WindowService : IWindowService, IDisposable
     /// </summary>
     private void OnWindowActivated(object? sender, EventArgs e)
     {
-        // 仅在桌面置顶模式下处理
+        // 普通模式和系统置顶模式无需重复纠正层级。
         if (_currentTopmostMode == TopmostMode.Desktop && _window != null)
         {
             var hwnd = new WindowInteropHelper(_window).Handle;
             if (hwnd != IntPtr.Zero)
             {
-                // 延迟执行，确保窗口激活完成后再调整层级
+                // 延后到后台优先级执行，避免与当前激活过程抢占消息循环。
                 System.Windows.Threading.Dispatcher.CurrentDispatcher.BeginInvoke(
                     new Action(() => SetDesktopTopmost(hwnd)),
                     System.Windows.Threading.DispatcherPriority.Background);
@@ -442,7 +459,7 @@ public class WindowService : IWindowService, IDisposable
 
         _disposed = true;
         
-        // 取消订阅窗口激活事件
+        // 释放前取消事件订阅，避免窗口对象被服务意外持有。
         if (_window != null && _isWindowActivatedHandlerAttached)
         {
             _window.Activated -= OnWindowActivated;


### PR DESCRIPTION
This pull request focuses on improving code clarity and maintainability by adding detailed comments and documentation throughout the codebase, especially in the application entry point, localization service, and main window logic. Additionally, it updates repository references in documentation files to reflect the new GitHub organization. The most important changes are summarized below:

### Documentation and Code Comments

* Added comprehensive XML and inline comments to `App.xaml.cs`, `LocalizationService.cs`, and `MainWindow.xaml.cs` to clarify the purpose, lifecycle, and rationale behind key methods, services registration, exception handling, localization logic, and window management. This makes the codebase more accessible to new contributors and easier to maintain. [[1]](diffhunk://#diff-7896ec19c3a3bd745b47b5d37437273871558ab79a2d6556fde87403a8a759fcR15-R18) [[2]](diffhunk://#diff-7896ec19c3a3bd745b47b5d37437273871558ab79a2d6556fde87403a8a759fcR28-R60) [[3]](diffhunk://#diff-7896ec19c3a3bd745b47b5d37437273871558ab79a2d6556fde87403a8a759fcL67-R78) [[4]](diffhunk://#diff-7896ec19c3a3bd745b47b5d37437273871558ab79a2d6556fde87403a8a759fcL117-R124) [[5]](diffhunk://#diff-7896ec19c3a3bd745b47b5d37437273871558ab79a2d6556fde87403a8a759fcL138-R145) [[6]](diffhunk://#diff-7896ec19c3a3bd745b47b5d37437273871558ab79a2d6556fde87403a8a759fcL148-R155) [[7]](diffhunk://#diff-7896ec19c3a3bd745b47b5d37437273871558ab79a2d6556fde87403a8a759fcR175-R177) [[8]](diffhunk://#diff-7896ec19c3a3bd745b47b5d37437273871558ab79a2d6556fde87403a8a759fcL179-R189) [[9]](diffhunk://#diff-7896ec19c3a3bd745b47b5d37437273871558ab79a2d6556fde87403a8a759fcL203-R213) [[10]](diffhunk://#diff-5fe73b81c17b1738a4916a4bf2e413652f6ff50441fbf0bd2fd37b50fbfb88aeL9-R17) [[11]](diffhunk://#diff-5fe73b81c17b1738a4916a4bf2e413652f6ff50441fbf0bd2fd37b50fbfb88aeL28-R35) [[12]](diffhunk://#diff-5fe73b81c17b1738a4916a4bf2e413652f6ff50441fbf0bd2fd37b50fbfb88aeL49-R50) [[13]](diffhunk://#diff-5fe73b81c17b1738a4916a4bf2e413652f6ff50441fbf0bd2fd37b50fbfb88aeL59-R60) [[14]](diffhunk://#diff-5fe73b81c17b1738a4916a4bf2e413652f6ff50441fbf0bd2fd37b50fbfb88aeL76-R87) [[15]](diffhunk://#diff-5fe73b81c17b1738a4916a4bf2e413652f6ff50441fbf0bd2fd37b50fbfb88aeL101-R102) [[16]](diffhunk://#diff-5fe73b81c17b1738a4916a4bf2e413652f6ff50441fbf0bd2fd37b50fbfb88aeL114-R115) [[17]](diffhunk://#diff-e9474bdaea88bacd9f0d42fcd68726d6971bf1b89bdca043106d6075773397fdR20-R32) [[18]](diffhunk://#diff-e9474bdaea88bacd9f0d42fcd68726d6971bf1b89bdca043106d6075773397fdR68-R83) [[19]](diffhunk://#diff-e9474bdaea88bacd9f0d42fcd68726d6971bf1b89bdca043106d6075773397fdR128-R130) [[20]](diffhunk://#diff-e9474bdaea88bacd9f0d42fcd68726d6971bf1b89bdca043106d6075773397fdL126-R139) [[21]](diffhunk://#diff-e9474bdaea88bacd9f0d42fcd68726d6971bf1b89bdca043106d6075773397fdL139-R157) [[22]](diffhunk://#diff-e9474bdaea88bacd9f0d42fcd68726d6971bf1b89bdca043106d6075773397fdL165-R177) [[23]](diffhunk://#diff-e9474bdaea88bacd9f0d42fcd68726d6971bf1b89bdca043106d6075773397fdL177-R193) [[24]](diffhunk://#diff-e9474bdaea88bacd9f0d42fcd68726d6971bf1b89bdca043106d6075773397fdL191-R203)

### Repository Reference Updates

* Updated all documentation and README files to use the new GitHub organization `SaltedCollection` instead of `SaltedDoubao`, ensuring that clone URLs, contributor images, and star history charts point to the correct repository. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R78) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L180-R186) [[3]](diffhunk://#diff-4f212053d7c510c6df117a36fa56a4dbacb596e78b0d0d0b5e678a61c8561c19L78-R78) [[4]](diffhunk://#diff-4f212053d7c510c6df117a36fa56a4dbacb596e78b0d0d0b5e678a61c8561c19L180-R186) [[5]](diffhunk://#diff-4c6b93aa75d5affde60dc3849606c9acd75ed444d52e99f3055fc0c7aa77e9e0L52-R52) [[6]](diffhunk://#diff-4c6b93aa75d5affde60dc3849606c9acd75ed444d52e99f3055fc0c7aa77e9e0L652-R653)

These changes collectively improve the developer experience, reduce confusion, and ensure that new contributors can quickly understand the project structure and logic.